### PR TITLE
Encode comparison name in header link

### DIFF
--- a/src/app/components/Header.jsx
+++ b/src/app/components/Header.jsx
@@ -356,7 +356,7 @@ export default class Header extends TranslatedComponent {
       let comps =  Object.keys(Persist.getComparisons()).sort();
 
       for (let name of comps) {
-        comparisons.push(<ActiveLink key={name} href={'/compare/' + name} className='block name'>{name}</ActiveLink>);
+        comparisons.push(<ActiveLink key={name} href={'/compare/' + encodeURIComponent(name)} className='block name'>{name}</ActiveLink>);
       }
     } else {
       comparisons = <span className='cap'>{translate('none created')}</span>;


### PR DESCRIPTION
I named a comparison "Why Engineer?" the other day, and it wouldn't load from the header, since the correct URL was `https://coriolis.edcd.io/compare/Why%20Engineer%3F` but the header linked to `https://coriolis.edcd.io/compare/Why%20Engineer?`. This just uses `encodeURIComponent` one the name to avoid that.

NOTE: I wasn't able to spin up a dev environment to test this change, but it appeared straightforward enough that I figured it was quicker to send a PR than it was to open an issue.