### PR TITLE
Add commas to slot cost

### DIFF
--- a/src/app/utils/SlotFunctions.js
+++ b/src/app/utils/SlotFunctions.js
@@ -220,7 +220,7 @@ export function diffDetails(language, m, mm) {
 
   let mCost = m.cost || 0;
   let mmCost = mm ? mm.cost : 0;
-  if (mCost != mmCost) propDiffs.push(<div key='cost'>{translate('cost')}: <span className={diffClass(mCost, mmCost, true) }>{mCost ? Math.round(mCost * (1 - Persist.getModuleDiscount())) : 0}{units.CR}</span></div>);
+  if (mCost != mmCost) propDiffs.push(<div key='cost'>{translate('cost')}: <span className={diffClass(mCost, mmCost, true) }>{formats.int(mCost ? Math.round(mCost * (1 - Persist.getModuleDiscount())) : 0)}{units.CR}</span></div>);
 
   let mMass = m.mass || 0;
   let mmMass = mm ? mm.getMass() : 0;


### PR DESCRIPTION
Adds commas to the cost of modules when hovering over them. Not only is this more clear, but it is consistent with the way all other costs are rendered.

Closes #169