### PR TITLE
Disable 'localhost' host header requirement

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -5,6 +5,7 @@ var config = require('./webpack.config.dev');
 new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
+  disableHostCheck: true,
   headers: { "Access-Control-Allow-Origin": "*" },
   historyApiFallback: {
     rewrites: [


### PR DESCRIPTION
Disable host header so webpack allows more than 'localhost' access

Allow easier remote IE/Safari/Chrome/Edge compatibility testing.

I believe this also prepares for [webpack 2.4.3](https://github.com/webpack/webpack-dev-server/issues/882) changes.