### PR TITLE
Feature/#271 keyboard nav

### DIFF
--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -275,9 +275,12 @@ export default class AvailableModulesMenu extends TranslatedComponent {
         elems.push(<br key={'b' + m.grp + i} />);
         itemsOnThisRow = 0;
       }
-
+      /**
+       *  Todo: add Tab and Enter keyUp handlers, make sure focus wraps back to top/bottom of open menu element on Tab and shift-Tab but
+       *  remains inside open menu until closed or a selection is made
+       */
       elems.push(
-        <li key={m.id} className={classes} {...eventHandlers}>
+        <li key={m.id} className={classes} {...eventHandlers} tabIndex="0">
           {mount}
           {(mount ? ' ' : '') + m.class + m.rating + (m.missile ? '/' + m.missile : '') + (m.name ? ' ' + translate(m.name) : '')}
         </li>

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -154,7 +154,10 @@ export default class AvailableModulesMenu extends TranslatedComponent {
       list = [];
       // At present time slots with grouped options (Hardpoints and Internal) can be empty
       if (m) {
-        list.push(<div className='empty-c upp' key='empty' onClick={onSelect.bind(null, null)} >{translate('empty')}</div>);
+        let emptyId = 'empty';
+        if(this.firstSlotId == null) this.firstSlotId = emptyId;
+        let keyDown = this._keyDown.bind(this, onSelect);
+        list.push(<div className='empty-c upp' key={emptyId} data-id={emptyId} onClick={onSelect.bind(null, null)} onKeyDown={keyDown} tabIndex="0" ref={slotItem => this.slotItems[emptyId] = slotItem} >{translate('empty')}</div>);
       }
 
       // Need to regroup the modules by our own categorisation
@@ -367,13 +370,16 @@ export default class AvailableModulesMenu extends TranslatedComponent {
    */
 
   _keyDown(select, event) {
+    
     //console.log("KeyDown. Are we tracking focus? " + this.state.trackingFocus);
     var className = event.currentTarget.attributes['class'].value;
+    
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       select();
       return
     }
     var elemId = event.currentTarget.attributes['data-id'].value;
+    
     if (className.indexOf('disabled') < 0 && event.key == 'Tab') {
       if (event.shiftKey && elemId == this.firstSlotId) {
         event.preventDefault();
@@ -381,6 +387,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
         return;        
       }
       if (!event.shiftKey && elemId == this.lastSlotId) {
+        console.log("shift/tab. slotItems: %O", this.slotItems[this.firstSlotId]);
         event.preventDefault();
         this.slotItems[this.firstSlotId].focus();        
         return;

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -107,6 +107,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
     warning: PropTypes.func,
     firstSlotId: PropTypes.string,
     lastSlotId: PropTypes.string,
+    slotDiv: PropTypes.object
   };
 
   static defaultProps = {
@@ -463,6 +464,16 @@ export default class AvailableModulesMenu extends TranslatedComponent {
        * changing this to the Active item instead.
        */
       this.slotItems[this.firstSlotId].focus();
+    }
+  }
+
+  componentWillUnmount() {
+    
+    if(this.props.slotDiv) {
+      console.log("AvailableModulesMenu component will unmount. Set focus to slot");
+      this.props.slotDiv.focus();
+    } else {
+      console.log("AvailableModulesMenu component will unmount. No slotDiv prop present.");
     }
   }
 

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -120,6 +120,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
     super(props);
     this._hideDiff = this._hideDiff.bind(this);
     this.state = this._initState(props, context);
+    this.slotItems = [];// Array to hold keys for <li> refs. To be used to manipulate focus through the <li>s
   }
 
   /**
@@ -276,11 +277,16 @@ export default class AvailableModulesMenu extends TranslatedComponent {
         itemsOnThisRow = 0;
       }
       /**
-       *  Todo: add Tab and Enter keyUp handlers, make sure focus wraps back to top/bottom of open menu element on Tab and shift-Tab but
-       *  remains inside open menu until closed or a selection is made
+       * 
+       *  Added new "slotItems" ref array to allow us to move focus from one <li> to the next.
+       * 
+       *  Todo: add Tab, Enter, and possibly Esc keyUp handlers.
+       *  Make sure focus wraps back to top/bottom of open menu element on Tab   and shift-Tab but
+       *  remains inside open menu until closed (with Esc key) or a selection is made
+       * 
        */
       elems.push(
-        <li key={m.id} className={classes} {...eventHandlers} tabIndex="0">
+        <li key={m.id} className={classes} {...eventHandlers} tabIndex="0" ref={slotItem => this.slotItems[m.id] = slotItem}>
           {mount}
           {(mount ? ' ' : '') + m.class + m.rating + (m.missile ? '/' + m.missile : '') + (m.name ? ' ' + translate(m.name) : '')}
         </li>
@@ -398,6 +404,19 @@ export default class AvailableModulesMenu extends TranslatedComponent {
   componentDidMount() {
     if (this.groupElem) {  // Scroll to currently selected group
       this.node.scrollTop = this.groupElem.offsetTop;
+    }
+
+    /** 
+     * Set up array of keys for each slot <li> element.
+     *  Will use this to set focus as Tab key is pressed
+     *  and to keep focus inside the slot <ul> until 
+     *  Enter key is pressed (indicating a selection) or 
+     *  Esc key is pressed (to close the slot)
+     */
+    if (this.slotItems) {
+      var slotKeys = Object.keys(this.slotItems);// Gives us an array with the keys for each slot item
+      // to focus on nth slot item:
+      // this.slotItems[slotKeys[n]].focus();
     }
   }
 

--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -370,16 +370,12 @@ export default class AvailableModulesMenu extends TranslatedComponent {
    */
 
   _keyDown(select, event) {
-    
-    //console.log("KeyDown. Are we tracking focus? " + this.state.trackingFocus);
     var className = event.currentTarget.attributes['class'].value;
-    
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       select();
       return
     }
     var elemId = event.currentTarget.attributes['data-id'].value;
-    
     if (className.indexOf('disabled') < 0 && event.key == 'Tab') {
       if (event.shiftKey && elemId == this.firstSlotId) {
         event.preventDefault();
@@ -387,7 +383,6 @@ export default class AvailableModulesMenu extends TranslatedComponent {
         return;        
       }
       if (!event.shiftKey && elemId == this.lastSlotId) {
-        console.log("shift/tab. slotItems: %O", this.slotItems[this.firstSlotId]);
         event.preventDefault();
         this.slotItems[this.firstSlotId].focus();        
         return;

--- a/src/app/components/HardpointSlot.jsx
+++ b/src/app/components/HardpointSlot.jsx
@@ -97,11 +97,26 @@ export default class HardpointSlot extends Slot {
           { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
           { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-          { m && validMods.length > 0 ? <div className='r' ><button onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+          { m && validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {
       return  <div className={'empty'}>{translate('empty')}</div>;
+    }
+  }
+
+    /** Key Down handler
+   *  @param {SyntheticEvent} event Event
+   *  ToDo: see if this can be moved up
+   *  we do more or less the same thing
+   *  in every section when Enter key is pressed
+   *  on a focusable item
+   * 
+   */
+
+  keyDown(event) {
+    if (event.key == 'Enter') {
+      this._toggleModifications();
     }
   }
 }

--- a/src/app/components/HardpointSlot.jsx
+++ b/src/app/components/HardpointSlot.jsx
@@ -97,7 +97,7 @@ export default class HardpointSlot extends Slot {
           { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
           { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-          { m && validMods.length > 0 ? <div className='r' tabIndex="0" ><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+          { m && validMods.length > 0 ? <div className='r' tabIndex="0" ref={ modButton => this.modButton = modButton }><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {

--- a/src/app/components/HardpointSlot.jsx
+++ b/src/app/components/HardpointSlot.jsx
@@ -97,7 +97,7 @@ export default class HardpointSlot extends Slot {
           { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
           { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-          { m && validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+          { m && validMods.length > 0 ? <div className='r' tabIndex="0" ><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {
@@ -105,18 +105,4 @@ export default class HardpointSlot extends Slot {
     }
   }
 
-    /** Key Down handler
-   *  @param {SyntheticEvent} event Event
-   *  ToDo: see if this can be moved up
-   *  we do more or less the same thing
-   *  in every section when Enter key is pressed
-   *  on a focusable item
-   * 
-   */
-
-  keyDown(event) {
-    if (event.key == 'Enter') {
-      this._toggleModifications();
-    }
-  }
 }

--- a/src/app/components/InternalSlot.jsx
+++ b/src/app/components/InternalSlot.jsx
@@ -87,7 +87,7 @@ export default class InternalSlot extends Slot {
           { m.getHullReinforcement() ? <div className='l'>{translate('armour')}: {formats.int(m.getHullReinforcement() + ship.baseArmour * m.getModValue('hullboost') / 10000)}</div> : null }
           { m.getProtection() ? <div className='l'>{translate('protection')}: {formats.rPct(m.getProtection())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	  { m && validMods.length > 0 ? <div className='r' tabIndex="0" ><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	  { m && validMods.length > 0 ? <div className='r' tabIndex="0" ref={ modButton => this.modButton = modButton }><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {

--- a/src/app/components/InternalSlot.jsx
+++ b/src/app/components/InternalSlot.jsx
@@ -21,6 +21,21 @@ export default class InternalSlot extends Slot {
    * @param  {Object} u             Localized Units Map
    * @return {React.Component}      Slot contents
    */
+
+
+    /** Key Down handler
+   *  @param {SyntheticEvent} event Event
+   *  ToDo: see if this can be moved up
+   *  we do more or less the same thing
+   *  in every section when Enter key is pressed
+   *  on a focusable item
+   * 
+   */ 
+  keyDown(event) {
+    if (event.key == 'Enter') {
+      this._toggleModifications();
+    }
+  }
   _getSlotDetails(m, enabled, translate, formats, u) {
     if (m) {
       let classRating = m.class + m.rating;
@@ -85,7 +100,7 @@ export default class InternalSlot extends Slot {
           { m.getHullReinforcement() ? <div className='l'>{translate('armour')}: {formats.int(m.getHullReinforcement() + ship.baseArmour * m.getModValue('hullboost') / 10000)}</div> : null }
           { m.getProtection() ? <div className='l'>{translate('protection')}: {formats.rPct(m.getProtection())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	  { m && validMods.length > 0 ? <div className='r' ><button onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	  { m && validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {

--- a/src/app/components/InternalSlot.jsx
+++ b/src/app/components/InternalSlot.jsx
@@ -23,19 +23,6 @@ export default class InternalSlot extends Slot {
    */
 
 
-    /** Key Down handler
-   *  @param {SyntheticEvent} event Event
-   *  ToDo: see if this can be moved up
-   *  we do more or less the same thing
-   *  in every section when Enter key is pressed
-   *  on a focusable item
-   * 
-   */ 
-  keyDown(event) {
-    if (event.key == 'Enter') {
-      this._toggleModifications();
-    }
-  }
   _getSlotDetails(m, enabled, translate, formats, u) {
     if (m) {
       let classRating = m.class + m.rating;
@@ -100,7 +87,7 @@ export default class InternalSlot extends Slot {
           { m.getHullReinforcement() ? <div className='l'>{translate('armour')}: {formats.int(m.getHullReinforcement() + ship.baseArmour * m.getModValue('hullboost') / 10000)}</div> : null }
           { m.getProtection() ? <div className='l'>{translate('protection')}: {formats.rPct(m.getProtection())}</div> : null }
           { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	  { m && validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	  { m && validMods.length > 0 ? <div className='r' tabIndex="0" ><button tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
         </div>
       </div>;
     } else {

--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -27,7 +27,6 @@ export default class Modification extends TranslatedComponent {
     super(props);
     this.state = {};
     this.state.value = props.value;
-    console.log("_renderModifications. _keyDown? %O", this.props.onKeyDown);
   }
 
   /**

--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -16,7 +16,8 @@ export default class Modification extends TranslatedComponent {
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
     onKeyDown: PropTypes.func.isRequired,
-    modItems: PropTypes.array.isRequired
+    modItems: PropTypes.array.isRequired,
+    handleModChange: PropTypes.func.isRequired
   };
 
   /**
@@ -63,7 +64,10 @@ export default class Modification extends TranslatedComponent {
    * with each onBlur event, even when no change has actually been made to the field. 
    */
   _updateFinished() {
-   if (this.props.value != this.state.value) this.props.onChange();
+    if (this.props.value != this.state.value) {
+      this.props.handleModChange(true);
+      this.props.onChange();
+    }
   }
 
   /**

--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -15,7 +15,8 @@ export default class Modification extends TranslatedComponent {
     name: PropTypes.string.isRequired,
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    onKeyDown: PropTypes.func.isRequired
+    onKeyDown: PropTypes.func.isRequired,
+    modItems: PropTypes.array.isRequired
   };
 
   /**
@@ -87,7 +88,7 @@ export default class Modification extends TranslatedComponent {
     }
 
     return (
-      <div onBlur={this._updateFinished.bind(this)} className={'cb'} key={name}>
+      <div onBlur={this._updateFinished.bind(this)} className={'cb'} key={name} ref={ modItem => this.props.modItems[name] = modItem }>
         <div className={'cb'}>{translate(name, m.grp)}{symbol}</div>
         <NumberEditor className={'cb'} style={{ width: '90%', textAlign: 'center' }} step={0.01} stepModifier={1} decimals={2} value={this.state.value} onValueChange={this._updateValue.bind(this)} onKeyDown={ this.props.onKeyDown } />
       </div>

--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -14,7 +14,8 @@ export default class Modification extends TranslatedComponent {
     m: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     value: PropTypes.number.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func.isRequired
   };
 
   /**
@@ -26,6 +27,7 @@ export default class Modification extends TranslatedComponent {
     super(props);
     this.state = {};
     this.state.value = props.value;
+    console.log("_renderModifications. _keyDown? %O", this.props.onKeyDown);
   }
 
   /**
@@ -88,7 +90,7 @@ export default class Modification extends TranslatedComponent {
     return (
       <div onBlur={this._updateFinished.bind(this)} className={'cb'} key={name}>
         <div className={'cb'}>{translate(name, m.grp)}{symbol}</div>
-        <NumberEditor className={'cb'} style={{ width: '90%', textAlign: 'center' }} step={0.01} stepModifier={1} decimals={2} value={this.state.value} onValueChange={this._updateValue.bind(this)} />
+        <NumberEditor className={'cb'} style={{ width: '90%', textAlign: 'center' }} step={0.01} stepModifier={1} decimals={2} value={this.state.value} onValueChange={this._updateValue.bind(this)} onKeyDown={ this.props.onKeyDown } />
       </div>
     );
   }

--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -38,7 +38,6 @@ export default class Modification extends TranslatedComponent {
    */
   _updateValue(value) {
     const name = this.props.name;
-
     let scaledValue = Math.round(Number(value) * 100);
     // Limit to +1000% / -99.99%
     if (scaledValue > 100000) {
@@ -59,9 +58,12 @@ export default class Modification extends TranslatedComponent {
 
   /**
    * Triggered when an update to slider value is finished i.e. when losing focus
+   * 
+   * pnellesen (24/05/2018): added value check below - this should prevent experimental effects from being recalculated 
+   * with each onBlur event, even when no change has actually been made to the field. 
    */
   _updateFinished() {
-    this.props.onChange();
+   if (this.props.value != this.state.value) this.props.onChange();
   }
 
   /**

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -108,7 +108,11 @@ export default class ModificationsMenu extends TranslatedComponent {
     if (event.currentTarget.attributes['data-id']) elemId = event.currentTarget.attributes['data-id'].value;
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       event.stopPropagation();
-      this.modItems[elemId].click();
+      if (elemId != null) {
+        this.modItems[elemId].click();
+      } else {
+        event.currentTarget.click();
+      }
       return
     }
     if (event.key == 'Tab') {
@@ -202,6 +206,7 @@ export default class ModificationsMenu extends TranslatedComponent {
       if (!Modifications.modifications[modName].hidden) {
         const key = modName + (m.getModValue(modName) / 100 || 0);
         modifications.push(<Modification key={ key } ship={ ship } m={ m } name={ modName } value={ m.getModValue(modName) / 100 || 0 } onChange={ onChange } onKeyDown={ this._keyDown }/>);
+        // Need onKeyDown to handle tab/shift-tab while the number modifiers are open
       }
     }
     return modifications;
@@ -368,12 +373,12 @@ export default class ModificationsMenu extends TranslatedComponent {
           onContextMenu={stopCtxPropagation}
       >
         { showBlueprintsMenu | showSpecialsMenu ? '' : haveBlueprint ? 
-          <div className={ cn('section-menu button-inline-menu', { selected: blueprintMenuOpened })} style={{ cursor: 'pointer' }} onMouseOver={termtip.bind(null, blueprintTt)} onMouseOut={tooltip.bind(null, null)} onClick={_toggleBlueprintsMenu}>{blueprintLabel}</div> : 
-          <div className={ cn('section-menu button-inline-menu', { selected: blueprintMenuOpened })} style={{ cursor: 'pointer' }} onClick={_toggleBlueprintsMenu}>{translate('PHRASE_SELECT_BLUEPRINT')}</div> }
+          <div tabIndex="0" className={ cn('section-menu button-inline-menu', { selected: blueprintMenuOpened })} style={{ cursor: 'pointer' }} onMouseOver={termtip.bind(null, blueprintTt)} onMouseOut={tooltip.bind(null, null)} onClick={_toggleBlueprintsMenu} onKeyDown={ this._keyDown }>{blueprintLabel}</div> : 
+          <div tabIndex="0" className={ cn('section-menu button-inline-menu', { selected: blueprintMenuOpened })} style={{ cursor: 'pointer' }} onClick={_toggleBlueprintsMenu} onKeyDown={ this._keyDown }>{translate('PHRASE_SELECT_BLUEPRINT')}</div> }
         { showBlueprintsMenu ? this._renderBlueprints(this.props, this.context) : null }
-        { showSpecial & !showSpecialsMenu ? <div className={ cn('section-menu button-inline-menu', { selected: specialMenuOpened })} style={{ cursor: 'pointer' }} onMouseOver={specialTt ? termtip.bind(null, specialTt) : null} onMouseOut={specialTt ? tooltip.bind(null, null) : null}  onClick={_toggleSpecialsMenu}>{specialLabel}</div> : null }
+        { showSpecial & !showSpecialsMenu ? <div tabIndex="0" className={ cn('section-menu button-inline-menu', { selected: specialMenuOpened })} style={{ cursor: 'pointer' }} onMouseOver={specialTt ? termtip.bind(null, specialTt) : null} onMouseOut={specialTt ? tooltip.bind(null, null) : null}  onClick={_toggleSpecialsMenu} onKeyDown={ this._keyDown }>{specialLabel}</div> : null }
         { showSpecialsMenu ? specials : null }
-        { showReset ? <div className={'section-menu button-inline-menu warning'} style={{ cursor: 'pointer' }} onClick={_reset} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RESET')} onMouseOut={tooltip.bind(null, null)}> { translate('reset') } </div> : null }
+        { showReset ? <div tabIndex="0" className={'section-menu button-inline-menu warning'} style={{ cursor: 'pointer' }} onClick={_reset} onKeyDown={ this._keyDown } onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RESET')} onMouseOut={tooltip.bind(null, null)}> { translate('reset') } </div> : null }
 		{ showRolls ?
             
             <table style={{ width: '100%', backgroundColor: 'transparent' }}>

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -45,11 +45,13 @@ export default class ModificationsMenu extends TranslatedComponent {
 
     this._keyDown = this._keyDown.bind(this);
 
-    this.modItems = [];// Array to hold <li> refs.
+    this.modItems = [];// Array to hold various element refs (<li>, <div>, <ul>, etc.)
     this.firstModId = null;
     this.firstBPLabel = null;// First item in mod menu
     this.lastModId = null;
     this.lastNeId = null;//Last number editor id. Used to set focus to last number editor when shift-tab pressed on first element in mod menu.
+    this.modValDidChange = false; //used to determine if component update was caused by change in modification value
+    this._handleModChange = this._handleModChange.bind(this);
 
     this.state = {
       blueprintMenuOpened: !(props.m.blueprint && props.m.blueprint.name),
@@ -156,7 +158,12 @@ export default class ModificationsMenu extends TranslatedComponent {
       }
     }
   }
-
+  /**
+   * set mod did change boolean
+   */
+  _handleModChange(b) {
+    this.modValDidChange = b;
+  }
 
   /**
    * Render the specials
@@ -214,8 +221,7 @@ export default class ModificationsMenu extends TranslatedComponent {
       if (!Modifications.modifications[modName].hidden) {
         const key = modName + (m.getModValue(modName) / 100 || 0);
         this.lastNeId = modName;
-        modifications.push(<Modification key={ key } ship={ ship } m={ m } name={ modName } value={ m.getModValue(modName) / 100 || 0 } onChange={ onChange } onKeyDown={ this._keyDown } modItems={ this.modItems }/>);
-        // Need onKeyDown to handle tab/shift-tab while the number modifiers are open
+        modifications.push(<Modification key={ key } ship={ ship } m={ m } name={ modName } value={ m.getModValue(modName) / 100 || 0 } onChange={ onChange } onKeyDown={ this._keyDown } modItems={ this.modItems } handleModChange = {this._handleModChange} />);
       }
     }
     console.log("_renderModifications. modItems: %O", this.modItems);
@@ -338,19 +344,22 @@ export default class ModificationsMenu extends TranslatedComponent {
     /**
      * Set focust on first element in modifications menu
      * if component updates
+     * 
+     * need a way to determine if update was due to a change in a modification,
+     * and if so bypass focus reset.
+     * 
      */
 
-    console.log("componentDidUpdate. prevState: %O", prevState);
-    console.log("componentDidUpdate. this.state: %O", this.state);
+    console.log("componentDidUpdate. modValDidChange: " + this.modValDidChange);
+    
     
 
-    if (this.modItems['modMainDiv'].firstElementChild.className.indexOf('button-inline-menu') >= 0) {
+    if (!this.modValDidChange && this.modItems['modMainDiv'].firstElementChild.className.indexOf('button-inline-menu') >= 0) {
       this.modItems['modMainDiv'].firstElementChild.focus();
-    } else if (this.modItems['modMainDiv'].children[1].tagName == "UL") {
-      console.log("modMainDiv children[1]: %O", this.modItems['modMainDiv'].children[1]);
+    } else if (!this.modValDidChange && this.modItems['modMainDiv'].children[1].tagName == "UL") {
       this.modItems['modMainDiv'].children[1].firstElementChild.focus();
-
     }
+    this.modValDidChange = false;//Need to reset after component update.
     
   }
 

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -105,6 +105,7 @@ export default class ModificationsMenu extends TranslatedComponent {
    * TODO: Add keyDown handler for Enter key to <td> tags for the "Rolls" section (~line 384 below)
    * 
    */
+  //_keyDown(event) {
   _keyDown(event) {
     var className = null;
     var elemId = null;

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -25,6 +25,7 @@ export default class ModificationsMenu extends TranslatedComponent {
     m: PropTypes.object.isRequired,
     marker: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    modButton:PropTypes.object
   };
 
   /**
@@ -376,6 +377,12 @@ export default class ModificationsMenu extends TranslatedComponent {
       this._handleModChange(false);//Need to reset if component update due to value change
     }
     
+  }
+
+  componentWillUnmount() {
+    if (this.props.modButton) {
+      this.props.modButton.focus();// set focus to the modification menu icon after mod menu is unmounted.
+    }
   }
 
   /**

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -105,10 +105,16 @@ export default class ModificationsMenu extends TranslatedComponent {
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       event.stopPropagation();
       this.modItems[elemId].click();
-      
       return
     }
     if (event.key == 'Tab') {
+      console.log("Tab key - target: %O", event.currentTarget);
+      /**
+       * For specials menus:
+       * currentTarget in specials menu will be "div.button-inline-menu". First item will be "div.button-inline-menu.warning"
+       * if nextElementSibling == null, it is the last element and focus should move to 'noExpEffect'
+       */
+      
       if (event.shiftKey && elemId == this.firstModId) {
         event.preventDefault();
         this.modItems[this.lastModId].focus();
@@ -131,6 +137,7 @@ export default class ModificationsMenu extends TranslatedComponent {
    * @return {Object}         list: Array of React Components
    */
   _renderSpecials(props, context) {
+    
     const { m } = props;
     const { language, tooltip, termtip } = context;
     const translate = language.translate;
@@ -138,7 +145,7 @@ export default class ModificationsMenu extends TranslatedComponent {
     const specialsId = m.missile && Modifications.modules[m.grp]['specials_' + m.missile] ? 'specials_' + m.missile : 'specials';
     if (Modifications.modules[m.grp][specialsId] && Modifications.modules[m.grp][specialsId].length > 0) {
       const close = this._specialSelected.bind(this, null);
-      specials.push(<div style={{ cursor: 'pointer', fontWeight: 'bold' }} className={ 'button-inline-menu warning' } key={ 'none' } onClick={ close }>{translate('PHRASE_NO_SPECIAL')}</div>);
+      specials.push(<div tabIndex="0" style={{ cursor: 'pointer', fontWeight: 'bold' }} className={ 'button-inline-menu warning' } key={ 'none' } data-id={ 'noExpEffect' } onClick={ close } onKeyDown={this._keyDown} ref={modItem => this.modItems['noExpEffect'] = modItem}>{translate('PHRASE_NO_SPECIAL')}</div>);
       for (const specialName of Modifications.modules[m.grp][specialsId]) {
         if (Modifications.specials[specialName].name.search('Legacy') >= 0) {
           continue;
@@ -157,12 +164,13 @@ export default class ModificationsMenu extends TranslatedComponent {
           m.blueprint.special = Modifications.specials[specialName];
           let specialTt = specialToolTip(translate, m.blueprint.grades[m.blueprint.grade], m.grp, m, specialName);
           m.blueprint.special = tmp;
-          specials.push(<div style={{ cursor: 'pointer' }} className={classes} key={ specialName } onMouseOver={termtip.bind(null, specialTt)} onMouseOut={tooltip.bind(null, null)} onClick={ close }>{translate(Modifications.specials[specialName].name)}</div>);
+          specials.push(<div tabIndex="0" style={{ cursor: 'pointer' }} className={classes} key={ specialName } data-id={ specialName } onMouseOver={termtip.bind(null, specialTt)} onMouseOut={tooltip.bind(null, null)} onClick={ close } onKeyDown={this._keyDown} ref={modItem => this.modItems[specialName] = modItem}>{translate(Modifications.specials[specialName].name)}</div>);
         } else {
-          specials.push(<div style={{ cursor: 'pointer' }} className={classes} key={ specialName } onClick={ close }>{translate(Modifications.specials[specialName].name)}</div>);
+          specials.push(<div tabIndex="0" style={{ cursor: 'pointer' }} className={classes} key={ specialName } data-id={ specialName }onClick={ close } onKeyDown={this._keyDown} ref={modItem => this.modItems[specialName] = modItem}>{translate(Modifications.specials[specialName].name)}</div>);
         }
       }
     }
+    console.log("_renderSpecials. specials: %O", specials);
     return specials;
   }
 
@@ -280,6 +288,12 @@ export default class ModificationsMenu extends TranslatedComponent {
 
     this.props.onChange();
   }
+
+  componentDidUpdate() {
+    console.log("componentDidUpdate - element selected className: " + event.target.className);
+    if (event.target.className == 'c' && this.modItems['noExpEffect']) this.modItems['noExpEffect'].focus();
+  }
+
 
   /**
    * Render the list

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -93,40 +93,56 @@ export default class ModificationsMenu extends TranslatedComponent {
     return blueprints;
   }
 
-/**
+  /**
    * Key down - select module on Enter key, move to next/previous module on Tab/Shift-Tab, close on Esc
    * @param  {Function} select Select module callback
    * @param  {SyntheticEvent} event Event
+   *
+   * TODO: Add keyDown handler for Enter key to <td> tags for the "Rolls" section (~line 384 below)
+   * 
    */
-
   _keyDown(event) {
-    var className = event.currentTarget.attributes['class'].value;
-    var elemId = event.currentTarget.attributes['data-id'].value;
+    var className = null;
+    var elemId = null;
+    if (event.currentTarget.attributes['class']) className = event.currentTarget.attributes['class'].value;
+    if (event.currentTarget.attributes['data-id']) elemId = event.currentTarget.attributes['data-id'].value;
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       event.stopPropagation();
       this.modItems[elemId].click();
       return
     }
     if (event.key == 'Tab') {
-      console.log("Tab key - target: %O", event.currentTarget);
-      /**
-       * For specials menus:
-       * currentTarget in specials menu will be "div.button-inline-menu". First item will be "div.button-inline-menu.warning"
-       * if nextElementSibling == null, it is the last element and focus should move to 'noExpEffect'
-       */
-      
-      if (event.shiftKey && elemId == this.firstModId) {
-        event.preventDefault();
-        this.modItems[this.lastModId].focus();
-        return;        
-      }
-      if (!event.shiftKey && elemId == this.lastModId) {
-        event.preventDefault();
-        this.modItems[this.firstModId].focus();        
-        return;
+      //Shift-Tab
+      if(event.shiftKey) {
+        console.log("Shift-Tab on - target: %O", event.currentTarget);
+        if (elemId == this.firstModId && elemId != null) {
+          // Initial modification menu
+          event.preventDefault();
+          this.modItems[this.lastModId].focus();
+          return;        
+        } else  if (event.currentTarget.className == "button-inline-menu warning") {
+          // Experimental menu
+          console.log("Shift-Tab on " + event.currentTarget.className);
+          event.preventDefault();
+          event.currentTarget.offsetParent.lastChild.focus();
+          return;
+        }
+      } else {
+        console.log("Tab key - target: %O", event.currentTarget);
+        if (elemId == this.lastModId && elemId != null) {
+          // Initial modification menu
+          event.preventDefault();
+          this.modItems[this.firstModId].focus();        
+          return;
+        } else if (event.currentTarget.className == "button-inline-menu" && event.currentTarget.nextSibling == null) {
+          // Experimental menu
+          event.preventDefault();
+          event.currentTarget.parentElement.firstElementChild.focus();
+          return;
+        } else if (event.currentTarget.className == 'cb' && event.currentTarget.parentElement.nextSibling == null)
+          console.log("Tab on last number input in mod menu");
       }
     }
-    
   }
 
 
@@ -185,7 +201,7 @@ export default class ModificationsMenu extends TranslatedComponent {
     for (const modName of Modifications.modules[m.grp].modifications) {
       if (!Modifications.modifications[modName].hidden) {
         const key = modName + (m.getModValue(modName) / 100 || 0);
-        modifications.push(<Modification key={ key } ship={ ship } m={ m } name={ modName } value={ m.getModValue(modName) / 100 || 0 } onChange={ onChange }/>);
+        modifications.push(<Modification key={ key } ship={ ship } m={ m } name={ modName } value={ m.getModValue(modName) / 100 || 0 } onChange={ onChange } onKeyDown={ this._keyDown }/>);
       }
     }
     return modifications;
@@ -292,6 +308,9 @@ export default class ModificationsMenu extends TranslatedComponent {
   componentDidUpdate() {
     console.log("componentDidUpdate - element selected className: " + event.target.className);
     if (event.target.className == 'c' && this.modItems['noExpEffect']) this.modItems['noExpEffect'].focus();
+    if (event.target.className == 'cb') {
+      console.log("mod input field - %O", event.target);
+    }
   }
 
 
@@ -361,11 +380,11 @@ export default class ModificationsMenu extends TranslatedComponent {
               <tbody>
           { showRolls ?
                 <tr>
-                  <td className={ cn('section-menu button-inline-menu', {active: false})}> { translate('roll') }: </td>
-                  <td className={ cn('section-menu button-inline-menu', { active: blueprintCv ===    0 })} style={{ cursor: 'pointer' }} onClick={_rollWorst} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_WORST')} onMouseOut={tooltip.bind(null, null)}> { translate('0%') } </td>
-                  <td className={ cn('section-menu button-inline-menu', { active: blueprintCv ===   50 })} style={{ cursor: 'pointer' }} onClick={_rollFifty} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_FIFTY')} onMouseOut={tooltip.bind(null, null)}> { translate('50%') } </td>
-                  <td className={ cn('section-menu button-inline-menu', { active: blueprintCv ===  100 })} style={{ cursor: 'pointer' }} onClick={_rollFull} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_BEST')} onMouseOut={tooltip.bind(null, null)}> { translate('100%') } </td>
-                  <td className={ cn('section-menu button-inline-menu', { active: blueprintCv === null || blueprintCv % 50 != 0 })} style={{ cursor: 'pointer' }} onClick={_rollRandom} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RANDOM')} onMouseOut={tooltip.bind(null, null)}> { translate('random') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', {active: false})}> { translate('roll') }: </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===    0 })} style={{ cursor: 'pointer' }} onClick={_rollWorst} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_WORST')} onMouseOut={tooltip.bind(null, null)}> { translate('0%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===   50 })} style={{ cursor: 'pointer' }} onClick={_rollFifty} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_FIFTY')} onMouseOut={tooltip.bind(null, null)}> { translate('50%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===  100 })} style={{ cursor: 'pointer' }} onClick={_rollFull} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_BEST')} onMouseOut={tooltip.bind(null, null)}> { translate('100%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv === null || blueprintCv % 50 != 0 })} style={{ cursor: 'pointer' }} onClick={_rollRandom} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RANDOM')} onMouseOut={tooltip.bind(null, null)}> { translate('random') } </td>
                 </tr> : null }
               </tbody>
           </table> : null }

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -128,7 +128,7 @@ export default class ModificationsMenu extends TranslatedComponent {
           event.preventDefault();
           this.modItems[this.lastModId].focus();
           return;        
-        } else  if (event.currentTarget.className == "section-menu button-inline-menu" && event.currentTarget.previousSibling == null && this.lastNeId != null) {
+        } else  if (event.currentTarget.className == "section-menu button-inline-menu" && event.currentTarget.previousSibling == null && this.lastNeId != null && this.modItems[this.lastNeId] != null) {
           // shift-tab on first element in modifications menu. set focus to last number editor field.
           event.preventDefault();
           this.modItems[this.lastNeId].lastChild.focus();
@@ -136,6 +136,7 @@ export default class ModificationsMenu extends TranslatedComponent {
         }
       } else {
         console.log("Tab key - target: %O", event.currentTarget);
+        
         if (elemId == this.lastModId && elemId != null) {
           // Initial modification menu
           event.preventDefault();
@@ -151,6 +152,7 @@ export default class ModificationsMenu extends TranslatedComponent {
           event.preventDefault();
           this.modItems[this.firstBPLabel].focus();
         }
+
       }
     }
   }
@@ -318,13 +320,40 @@ export default class ModificationsMenu extends TranslatedComponent {
     this.props.onChange();
   }
 
-  componentDidUpdate() {
-    console.log("componentDidUpdate - element selected className: " + event.target.className);
-    if (event.target.className == 'c' && this.modItems['noExpEffect']) this.modItems['noExpEffect'].focus();
-    if (event.target.className == 'cb') {
-      console.log("mod input field - %O", event.target);
+  componentDidMount() {
+    /**
+     * Set focus on first element in modifications menu
+     * after it first mounts
+     */
+    console.log("componentDidMount. modMainDiv: %O", this.modItems['modMainDiv']);
+    if (this.modItems['modMainDiv'].children[1].tagName == "UL") {
+      this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+    } else {
+      this.modItems['modMainDiv'].firstElementChild.focus();
     }
+    
   }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    /**
+     * Set focust on first element in modifications menu
+     * if component updates
+     */
+
+    console.log("componentDidUpdate. prevState: %O", prevState);
+    console.log("componentDidUpdate. this.state: %O", this.state);
+    
+
+    if (this.modItems['modMainDiv'].firstElementChild.className.indexOf('button-inline-menu') >= 0) {
+      this.modItems['modMainDiv'].firstElementChild.focus();
+    } else if (this.modItems['modMainDiv'].children[1].tagName == "UL") {
+      console.log("modMainDiv children[1]: %O", this.modItems['modMainDiv'].children[1]);
+      this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+
+    }
+    
+  }
+
 
 
   /**
@@ -383,6 +412,7 @@ export default class ModificationsMenu extends TranslatedComponent {
           className={cn('select', this.props.className)}
           onClick={(e) => e.stopPropagation() }
           onContextMenu={stopCtxPropagation}
+          ref={modItem => this.modItems['modMainDiv'] = modItem}
       >
         { showBlueprintsMenu | showSpecialsMenu ? '' : haveBlueprint ? 
           <div tabIndex="0" className={ cn('section-menu button-inline-menu', { selected: blueprintMenuOpened })} style={{ cursor: 'pointer' }} onMouseOver={termtip.bind(null, blueprintTt)} onMouseOut={tooltip.bind(null, null)} onClick={_toggleBlueprintsMenu} onKeyDown={ this._keyDown } ref={modItems => this.modItems[this.firstBPLabel] = modItems}>{blueprintLabel}</div> : 

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -103,19 +103,24 @@ export default class ModificationsMenu extends TranslatedComponent {
     var className = event.currentTarget.attributes['class'].value;
     var elemId = event.currentTarget.attributes['data-id'].value;
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
+      event.stopPropagation();
       this.modItems[elemId].click();
+      
       return
     }
-    if (event.shiftKey && elemId == this.firstModId) {
-      event.preventDefault();
-      this.modItems[this.lastModId].focus();
-      return;        
+    if (event.key == 'Tab') {
+      if (event.shiftKey && elemId == this.firstModId) {
+        event.preventDefault();
+        this.modItems[this.lastModId].focus();
+        return;        
+      }
+      if (!event.shiftKey && elemId == this.lastModId) {
+        event.preventDefault();
+        this.modItems[this.firstModId].focus();        
+        return;
+      }
     }
-    if (!event.shiftKey && elemId == this.lastModId) {
-      event.preventDefault();
-      this.modItems[this.firstModId].focus();        
-      return;
-    }
+    
   }
 
 

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -50,7 +50,7 @@ export default class ModificationsMenu extends TranslatedComponent {
     this.firstBPLabel = null;// First item in mod menu
     this.lastModId = null;
     this.lastNeId = null;//Last number editor id. Used to set focus to last number editor when shift-tab pressed on first element in mod menu.
-    this.modValDidChange = false; //used to determine if component update was caused by change in modification value
+    this.modValDidChange = false; //used to determine if component update was caused by change in modification value.
     this._handleModChange = this._handleModChange.bind(this);
 
     this.state = {
@@ -102,25 +102,24 @@ export default class ModificationsMenu extends TranslatedComponent {
    * @param  {Function} select Select module callback
    * @param  {SyntheticEvent} event Event
    *
-   * TODO: Add keyDown handler for Enter key to <td> tags for the "Rolls" section (~line 384 below)
-   * 
    */
-  //_keyDown(event) {
+  
   _keyDown(event) {
     var className = null;
     var elemId = null;
     if (event.currentTarget.attributes['class']) className = event.currentTarget.attributes['class'].value;
     if (event.currentTarget.attributes['data-id']) elemId = event.currentTarget.attributes['data-id'].value;
+    
     if (event.key == 'Enter' && className.indexOf('disabled') < 0 && className.indexOf('active') < 0) {
       event.stopPropagation();
       if (elemId != null) {
         this.modItems[elemId].click();
       } else {
+        
         event.currentTarget.click();
       }
       return
     }
-    
     if (event.key == 'Tab') {
       //Shift-Tab
       if(event.shiftKey) {
@@ -140,13 +139,12 @@ export default class ModificationsMenu extends TranslatedComponent {
           event.currentTarget.parentElement.lastElementChild.focus();
         }
       } else {
-        console.log("Tab key - target: %O", event.currentTarget);
         if (elemId == this.lastModId && elemId != null) {
           // Initial modification menu
           event.preventDefault();
           this.modItems[this.firstModId].focus();        
           return;
-        } else if (event.currentTarget.className.indexOf("button-inline-menu") >= 0 && event.currentTarget.nextSibling == null) {
+        } else if (event.currentTarget.className.indexOf("button-inline-menu") >= 0 && event.currentTarget.nextSibling == null && event.currentTarget.nodeName != "TD") {
           // Experimental menu
           event.preventDefault();
           event.currentTarget.parentElement.firstElementChild.focus();
@@ -176,7 +174,7 @@ export default class ModificationsMenu extends TranslatedComponent {
     const specialsId = m.missile && Modifications.modules[m.grp]['specials_' + m.missile] ? 'specials_' + m.missile : 'specials';
     if (Modifications.modules[m.grp][specialsId] && Modifications.modules[m.grp][specialsId].length > 0) {
       const close = this._specialSelected.bind(this, null);
-      specials.push(<div tabIndex="0" style={{ cursor: 'pointer', fontWeight: 'bold' }} className={ 'button-inline-menu warning' } key={ 'none' } data-id={ 'noExpEffect' } onClick={ close } onKeyDown={this._keyDown} ref={modItem => this.modItems['noExpEffect'] = modItem}>{translate('PHRASE_NO_SPECIAL')}</div>);
+      specials.push(<div tabIndex="0" style={{ cursor: 'pointer', fontWeight: 'bold' }} className={ 'button-inline-menu warning' } key={ 'none' } data-id={ 'none' } onClick={ close } onKeyDown={this._keyDown} ref={modItem => this.modItems['none'] = modItem}>{translate('PHRASE_NO_SPECIAL')}</div>);
       for (const specialName of Modifications.modules[m.grp][specialsId]) {
         if (Modifications.specials[specialName].name.search('Legacy') >= 0) {
           continue;
@@ -281,6 +279,10 @@ export default class ModificationsMenu extends TranslatedComponent {
   _rollFifty() {
     const { m, ship } = this.props;
     setPercent(ship, m, 50);
+    
+    // this will change the values in the modifications. Set modDidChange to true to prevent focus change when component updates
+    this._handleModChange(true);
+    
     this.props.onChange();
   }
 
@@ -290,6 +292,10 @@ export default class ModificationsMenu extends TranslatedComponent {
   _rollRandom() {
     const { m, ship } = this.props;
     setRandom(ship, m);
+    
+    // this will change the values in the modifications. Set modDidChange to true to prevent focus change when component updates
+    this._handleModChange(true);
+    
     this.props.onChange();
   }
 
@@ -299,6 +305,10 @@ export default class ModificationsMenu extends TranslatedComponent {
   _rollBest() {
     const { m, ship } = this.props;
     setPercent(ship, m, 100);
+    
+    // this will change the values in the modifications. Set modDidChange to true to prevent focus change when component updates
+    this._handleModChange(true);
+    
     this.props.onChange();
   }
 
@@ -308,7 +318,13 @@ export default class ModificationsMenu extends TranslatedComponent {
   _rollWorst() {
     const { m, ship } = this.props;
     setPercent(ship, m, 0);
+    
+    // this will change the values in the modifications. Set modDidChange to true to prevent focus change when component updates
+    this._handleModChange(true);
+    
     this.props.onChange();
+    
+
   }
 
   /**
@@ -318,7 +334,6 @@ export default class ModificationsMenu extends TranslatedComponent {
     const { m, ship } = this.props;
     ship.clearModifications(m);
     ship.clearModuleBlueprint(m);
-
     this.props.onChange();
   }
 
@@ -334,14 +349,12 @@ export default class ModificationsMenu extends TranslatedComponent {
      * Set focus on first element in modifications menu
      * after it first mounts
      */
-    let firstEleCn = this.modItems['modMainDiv'].children[0].className;
-    console.log("componentDidMount. modMainDiv first child: %O", this.modItems['modMainDiv'].children[0]);
+    let firstEleCn = this.modItems['modMainDiv'].children.length > 0 ? this.modItems['modMainDiv'].children[0].className : null;
     if (firstEleCn.indexOf('select-group cap') >= 0) {
       this.modItems['modMainDiv'].children[1].firstElementChild.focus();
     } else {
       this.modItems['modMainDiv'].firstElementChild.focus();
     }
-    
   }
 
   componentDidUpdate() {
@@ -351,20 +364,19 @@ export default class ModificationsMenu extends TranslatedComponent {
      * in a modification
      */
     if (!this.modValDidChange) {
-      console.log("componentDidUpdate. modMainDiv first child: %O", this.modItems['modMainDiv'].children[0]);
-      let firstEleCn = this.modItems['modMainDiv'].children[0].className;
-      if (firstEleCn.indexOf('button-inline-menu') >= 0) {
-        this.modItems['modMainDiv'].firstElementChild.focus();
-      } else if (firstEleCn.indexOf('select-group cap') >= 0)  {
-        this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+      if (this.modItems['modMainDiv'].children.length > 0) {
+        let firstEleCn = this.modItems['modMainDiv'].children[0].className;
+        if (firstEleCn.indexOf('button-inline-menu') >= 0) {
+          this.modItems['modMainDiv'].firstElementChild.focus();
+        } else if (firstEleCn.indexOf('select-group cap') >= 0)  {
+          this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+        }
       }
     } else {
       this._handleModChange(false);//Need to reset if component update due to value change
     }
     
   }
-
-
 
   /**
    * Render the list
@@ -405,13 +417,16 @@ export default class ModificationsMenu extends TranslatedComponent {
     }
 
     const specials = this._renderSpecials(this.props, this.context);
-
+    /**
+     * pnellesen - 05/28/2018 - added additional checks for specials.length below to ensure menus
+     * display correctly in cases where there are no specials (ex: AFMUs.)
+     */
     const showBlueprintsMenu = blueprintMenuOpened;
     const showSpecial = haveBlueprint && specials.length && !blueprintMenuOpened;
-    const showSpecialsMenu = specialMenuOpened;
-    const showRolls = haveBlueprint && !blueprintMenuOpened && !specialMenuOpened;
-    const showReset = !blueprintMenuOpened && !specialMenuOpened && haveBlueprint;
-    const showMods = !blueprintMenuOpened && !specialMenuOpened && haveBlueprint;
+    const showSpecialsMenu = specialMenuOpened && specials.length;
+    const showRolls = haveBlueprint && !blueprintMenuOpened && (!specialMenuOpened || !specials.length);
+    const showReset = !blueprintMenuOpened && (!specialMenuOpened || !specials.length) && haveBlueprint;
+    const showMods = !blueprintMenuOpened && (!specialMenuOpened || !specials.length) && haveBlueprint;
     if (haveBlueprint) {
       this.firstBPLabel = blueprintLabel
     } else {
@@ -438,10 +453,10 @@ export default class ModificationsMenu extends TranslatedComponent {
           { showRolls ?
                 <tr>
                   <td tabIndex="0" className={ cn('section-menu button-inline-menu', {active: false})}> { translate('roll') }: </td>
-                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===    0 })} style={{ cursor: 'pointer' }} onClick={_rollWorst} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_WORST')} onMouseOut={tooltip.bind(null, null)}> { translate('0%') } </td>
-                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===   50 })} style={{ cursor: 'pointer' }} onClick={_rollFifty} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_FIFTY')} onMouseOut={tooltip.bind(null, null)}> { translate('50%') } </td>
-                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===  100 })} style={{ cursor: 'pointer' }} onClick={_rollFull} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_BEST')} onMouseOut={tooltip.bind(null, null)}> { translate('100%') } </td>
-                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv === null || blueprintCv % 50 != 0 })} style={{ cursor: 'pointer' }} onClick={_rollRandom} onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RANDOM')} onMouseOut={tooltip.bind(null, null)}> { translate('random') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===    0 })} style={{ cursor: 'pointer' }} onClick={_rollWorst} onKeyDown={ this._keyDown } onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_WORST')} onMouseOut={tooltip.bind(null, null)}> { translate('0%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===   50 })} style={{ cursor: 'pointer' }} onClick={_rollFifty} onKeyDown={ this._keyDown } onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_FIFTY')} onMouseOut={tooltip.bind(null, null)}> { translate('50%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv ===  100 })} style={{ cursor: 'pointer' }} onClick={_rollFull} onKeyDown={ this._keyDown } onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_BEST')} onMouseOut={tooltip.bind(null, null)}> { translate('100%') } </td>
+                  <td tabIndex="0" className={ cn('section-menu button-inline-menu', { active: blueprintCv === null || blueprintCv % 50 != 0 })} style={{ cursor: 'pointer' }} onClick={_rollRandom} onKeyDown={ this._keyDown } onMouseOver={termtip.bind(null, 'PHRASE_BLUEPRINT_RANDOM')} onMouseOut={tooltip.bind(null, null)}> { translate('random') } </td>
                 </tr> : null }
               </tbody>
           </table> : null }

--- a/src/app/components/ModificationsMenu.jsx
+++ b/src/app/components/ModificationsMenu.jsx
@@ -123,34 +123,34 @@ export default class ModificationsMenu extends TranslatedComponent {
     if (event.key == 'Tab') {
       //Shift-Tab
       if(event.shiftKey) {
-        console.log("shift-Tab key. elemId: " + elemId + " - this.firstModId: " + this.firstModId);
         if (elemId == this.firstModId && elemId != null) {
           // Initial modification menu
-          
           event.preventDefault();
           this.modItems[this.lastModId].focus();
           return;        
-        } else  if (event.currentTarget.className == "section-menu button-inline-menu" && event.currentTarget.previousSibling == null && this.lastNeId != null && this.modItems[this.lastNeId] != null) {
-          // shift-tab on first element in modifications menu. set focus to last number editor field.
+        } else  if (event.currentTarget.className.indexOf("button-inline-menu") >= 0 && event.currentTarget.previousElementSibling == null && this.lastNeId != null && this.modItems[this.lastNeId] != null) {
+          // shift-tab on first element in modifications menu. set focus to last number editor field if open
           event.preventDefault();
           this.modItems[this.lastNeId].lastChild.focus();
           return;
+        } else if (event.currentTarget.className.indexOf("button-inline-menu") >= 0 && event.currentTarget.previousElementSibling == null) {
+          // shift-tab on button-inline-menu with no number editor
+          event.preventDefault();
+          event.currentTarget.parentElement.lastElementChild.focus();
         }
       } else {
         console.log("Tab key - target: %O", event.currentTarget);
-        
         if (elemId == this.lastModId && elemId != null) {
           // Initial modification menu
           event.preventDefault();
           this.modItems[this.firstModId].focus();        
           return;
-        } else if (event.currentTarget.className == "button-inline-menu" && event.currentTarget.nextSibling == null) {
+        } else if (event.currentTarget.className.indexOf("button-inline-menu") >= 0 && event.currentTarget.nextSibling == null) {
           // Experimental menu
           event.preventDefault();
           event.currentTarget.parentElement.firstElementChild.focus();
           return;
         } else if (event.currentTarget.className == 'cb' && event.currentTarget.parentElement.nextSibling == null) {
-          console.log("Tab on last number input in mod menu");
           event.preventDefault();
           this.modItems[this.firstBPLabel].focus();
         }
@@ -158,12 +158,7 @@ export default class ModificationsMenu extends TranslatedComponent {
       }
     }
   }
-  /**
-   * set mod did change boolean
-   */
-  _handleModChange(b) {
-    this.modValDidChange = b;
-  }
+  
 
   /**
    * Render the specials
@@ -326,13 +321,21 @@ export default class ModificationsMenu extends TranslatedComponent {
     this.props.onChange();
   }
 
+/**
+   * set mod did change boolean
+   */
+  _handleModChange(b) {
+    this.modValDidChange = b;
+  }
+
   componentDidMount() {
     /**
      * Set focus on first element in modifications menu
      * after it first mounts
      */
-    console.log("componentDidMount. modMainDiv: %O", this.modItems['modMainDiv']);
-    if (this.modItems['modMainDiv'].children[1].tagName == "UL") {
+    let firstEleCn = this.modItems['modMainDiv'].children[0].className;
+    console.log("componentDidMount. modMainDiv first child: %O", this.modItems['modMainDiv'].children[0]);
+    if (firstEleCn.indexOf('select-group cap') >= 0) {
       this.modItems['modMainDiv'].children[1].firstElementChild.focus();
     } else {
       this.modItems['modMainDiv'].firstElementChild.focus();
@@ -340,26 +343,23 @@ export default class ModificationsMenu extends TranslatedComponent {
     
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
+  componentDidUpdate() {
     /**
-     * Set focust on first element in modifications menu
-     * if component updates
-     * 
-     * need a way to determine if update was due to a change in a modification,
-     * and if so bypass focus reset.
-     * 
+     * Set focus on first element in modifications menu
+     * if component updates, unless update is due to value change
+     * in a modification
      */
-
-    console.log("componentDidUpdate. modValDidChange: " + this.modValDidChange);
-    
-    
-
-    if (!this.modValDidChange && this.modItems['modMainDiv'].firstElementChild.className.indexOf('button-inline-menu') >= 0) {
-      this.modItems['modMainDiv'].firstElementChild.focus();
-    } else if (!this.modValDidChange && this.modItems['modMainDiv'].children[1].tagName == "UL") {
-      this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+    if (!this.modValDidChange) {
+      console.log("componentDidUpdate. modMainDiv first child: %O", this.modItems['modMainDiv'].children[0]);
+      let firstEleCn = this.modItems['modMainDiv'].children[0].className;
+      if (firstEleCn.indexOf('button-inline-menu') >= 0) {
+        this.modItems['modMainDiv'].firstElementChild.focus();
+      } else if (firstEleCn.indexOf('select-group cap') >= 0)  {
+        this.modItems['modMainDiv'].children[1].firstElementChild.focus();
+      }
+    } else {
+      this._handleModChange(false);//Need to reset if component update due to value change
     }
-    this.modValDidChange = false;//Need to reset after component update.
     
   }
 

--- a/src/app/components/Slot.jsx
+++ b/src/app/components/Slot.jsx
@@ -121,7 +121,7 @@ export default class Slot extends TranslatedComponent {
     // TODO: implement touch dragging
 
     return (
-      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onContextMenu={this._contextMenu} onDragOver={dragOver}>
+      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onContextMenu={this._contextMenu} onDragOver={dragOver} tabIndex="0">
         <div className='details-container'>
           <div className='sz'>{this._getMaxClassLabel(translate)}</div>
             {slotDetails}

--- a/src/app/components/Slot.jsx
+++ b/src/app/components/Slot.jsx
@@ -41,6 +41,7 @@ export default class Slot extends TranslatedComponent {
     this._contextMenu = wrapCtxMenu(this._contextMenu.bind(this));
     this._getMaxClassLabel = this._getMaxClassLabel.bind(this);
     this._keyDown = this._keyDown.bind(this);
+    this.slotDiv = null;
   }
 
   // Must be implemented by subclasses:
@@ -124,6 +125,7 @@ export default class Slot extends TranslatedComponent {
           ship={ship}
           m={m}
           marker={modificationsMarker}
+          modButton = {this.modButton}
         />;
       } else {
         menu = <AvailableModulesMenu
@@ -134,6 +136,7 @@ export default class Slot extends TranslatedComponent {
           onSelect={onSelect}
           warning={warning}
           diffDetails={diffDetails.bind(ship, this.context.language)}
+          slotDiv = {this.slotDiv}
         />;
       }
     }
@@ -141,7 +144,7 @@ export default class Slot extends TranslatedComponent {
     // TODO: implement touch dragging
 
     return (
-      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onKeyDown={this._keyDown} onContextMenu={this._contextMenu} onDragOver={dragOver} tabIndex="0">
+      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onKeyDown={this._keyDown} onContextMenu={this._contextMenu} onDragOver={dragOver} tabIndex="0" ref={slotDiv => this.slotDiv = slotDiv}>
         <div className='details-container'>
           <div className='sz'>{this._getMaxClassLabel(translate)}</div>
             {slotDetails}

--- a/src/app/components/Slot.jsx
+++ b/src/app/components/Slot.jsx
@@ -84,8 +84,13 @@ export default class Slot extends TranslatedComponent {
    */
   _keyDown(event) {
     if (event.key == 'Enter') {
-      console.log("Enter key pressed. Event target: %O", event.currentTarget);
-      this.props.onOpen(event);
+        if(event.target.className == 'r') {
+            console.log("Slot: Enter key pressed on mod icon");
+            this._toggleModifications();
+        } else {
+            console.log("Slot: Enter key pressed on: %O", event.target);
+        }
+        this.props.onOpen(event); 
     }
   }
   /**

--- a/src/app/components/Slot.jsx
+++ b/src/app/components/Slot.jsx
@@ -40,6 +40,7 @@ export default class Slot extends TranslatedComponent {
 
     this._contextMenu = wrapCtxMenu(this._contextMenu.bind(this));
     this._getMaxClassLabel = this._getMaxClassLabel.bind(this);
+    this._keyDown = this._keyDown.bind(this);
   }
 
   // Must be implemented by subclasses:
@@ -72,7 +73,11 @@ export default class Slot extends TranslatedComponent {
     event.preventDefault();
     this.props.onSelect(null,null);
   }
-
+  _keyDown(event) {
+    if (event.key == 'Enter') {
+      this.props.onOpen(event);
+    }
+  }
   /**
    * Render the slot
    * @return {React.Component} The slot
@@ -121,7 +126,7 @@ export default class Slot extends TranslatedComponent {
     // TODO: implement touch dragging
 
     return (
-      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onContextMenu={this._contextMenu} onDragOver={dragOver} tabIndex="0">
+      <div className={cn('slot', dropClass, { selected })} onClick={onOpen} onKeyDown={this._keyDown} onContextMenu={this._contextMenu} onDragOver={dragOver} tabIndex="0">
         <div className='details-container'>
           <div className='sz'>{this._getMaxClassLabel(translate)}</div>
             {slotDetails}

--- a/src/app/components/Slot.jsx
+++ b/src/app/components/Slot.jsx
@@ -73,8 +73,18 @@ export default class Slot extends TranslatedComponent {
     event.preventDefault();
     this.props.onSelect(null,null);
   }
+
+  /** Key Down handler
+   *  @param {SyntheticEvent} event Event
+   *  ToDo: see if this can be moved up
+   *  we do more or less the same thing
+   *  in every section when Enter key is pressed
+   *  on a focusable item
+   * 
+   */
   _keyDown(event) {
     if (event.key == 'Enter') {
+      console.log("Enter key pressed. Event target: %O", event.currentTarget);
       this.props.onOpen(event);
     }
   }
@@ -136,6 +146,7 @@ export default class Slot extends TranslatedComponent {
     );
   }
 
+  
   /**
    * Toggle the modifications flag when selecting the modifications icon
    */

--- a/src/app/components/StandardSlot.jsx
+++ b/src/app/components/StandardSlot.jsx
@@ -97,7 +97,7 @@ export default class StandardSlot extends TranslatedComponent {
     }
 
     return (
-      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onContextMenu={stopCtxPropagation}>
+      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onContextMenu={stopCtxPropagation} tabIndex="0">
         <div className={cn('details-container', { warning: warning && warning(slot.m), disabled: m.grp !== 'bh' && !slot.enabled })}>
           <div className={'sz'}>{m.grp == 'bh' ? m.name.charAt(0) : slot.maxClass}</div>
           <div>

--- a/src/app/components/StandardSlot.jsx
+++ b/src/app/components/StandardSlot.jsx
@@ -38,9 +38,12 @@ export default class StandardSlot extends TranslatedComponent {
     this._keyDown = this._keyDown.bind(this);
   }
 
-  _keyDown(event) {
+   _keyDown(event) {
     if (event.key == 'Enter') {
-      this.props.onOpen(event);
+        if(event.target.className == 'r') {
+            this._toggleModifications();
+        }
+        this.props.onOpen(event); 
     }
   }
 
@@ -128,27 +131,13 @@ export default class StandardSlot extends TranslatedComponent {
                 { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
                 { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
                 { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	        { validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button  tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	        { validMods.length > 0 ? <div className='r' tabIndex="0"><button  tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
             </div>
           </div>
         </div>
         {menu}
       </div>
     );
-  }
-
-    /** Key Down handler
-   *  @param {SyntheticEvent} event Event
-   *  ToDo: see if this can be moved up
-   *  we do more or less the same thing
-   *  in every section when Enter key is pressed
-   *  on a focusable item
-   * 
-   */
-  keyDown(event) {
-    if (event.key == 'Enter') {
-      this._toggleModifications();
-    }
   }
 
   /**

--- a/src/app/components/StandardSlot.jsx
+++ b/src/app/components/StandardSlot.jsx
@@ -36,6 +36,8 @@ export default class StandardSlot extends TranslatedComponent {
     super(props);
     this._modificationsSelected = false;
     this._keyDown = this._keyDown.bind(this);
+    this.modButton = null;
+    this.slotDiv = null;
   }
 
    _keyDown(event) {
@@ -92,6 +94,7 @@ export default class StandardSlot extends TranslatedComponent {
           ship={ship}
           m={m}
           marker={modificationsMarker}
+          modButton = {this.modButton}
         />;
       } else {
         menu = <AvailableModulesMenu
@@ -102,12 +105,13 @@ export default class StandardSlot extends TranslatedComponent {
           onSelect={onSelect}
           warning={warning}
           diffDetails={diffDetails.bind(ship, this.context.language)}
+          slotDiv = {this.slotDiv}
         />;
       }
     }
 
     return (
-      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onKeyDown={this._keyDown} onContextMenu={stopCtxPropagation} tabIndex="0">
+      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onKeyDown={this._keyDown} onContextMenu={stopCtxPropagation} tabIndex="0" ref={ slotDiv => this.slotDiv = slotDiv }>
         <div className={cn('details-container', { warning: warning && warning(slot.m), disabled: m.grp !== 'bh' && !slot.enabled })}>
           <div className={'sz'}>{m.grp == 'bh' ? m.name.charAt(0) : slot.maxClass}</div>
           <div>
@@ -131,7 +135,7 @@ export default class StandardSlot extends TranslatedComponent {
                 { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
                 { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
                 { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	        { validMods.length > 0 ? <div className='r' tabIndex="0"><button  tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	        { validMods.length > 0 ? <div className='r' tabIndex="0" ref={ modButton => this.modButton = modButton }><button  tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
             </div>
           </div>
         </div>

--- a/src/app/components/StandardSlot.jsx
+++ b/src/app/components/StandardSlot.jsx
@@ -128,7 +128,7 @@ export default class StandardSlot extends TranslatedComponent {
                 { showModuleResistances && m.getKineticResistance() ? <div className='l'>{translate('kinres')}: {formats.pct(m.getKineticResistance())}</div> : null }
                 { showModuleResistances && m.getThermalResistance() ? <div className='l'>{translate('thermres')}: {formats.pct(m.getThermalResistance())}</div> : null }
                 { m.getIntegrity() ? <div className='l'>{translate('integrity')}: {formats.int(m.getIntegrity())}</div> : null }
-	        { validMods.length > 0 ? <div className='r' ><button onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
+	        { validMods.length > 0 ? <div className='r' tabIndex="0" onKeyDown={this.keyDown.bind(this)}><button  tabIndex="-1" onClick={this._toggleModifications.bind(this)} onContextMenu={stopCtxPropagation} onMouseOver={termtip.bind(null, 'modifications')} onMouseOut={tooltip.bind(null, null)}><ListModifications /></button></div> : null }
             </div>
           </div>
         </div>
@@ -137,10 +137,25 @@ export default class StandardSlot extends TranslatedComponent {
     );
   }
 
+    /** Key Down handler
+   *  @param {SyntheticEvent} event Event
+   *  ToDo: see if this can be moved up
+   *  we do more or less the same thing
+   *  in every section when Enter key is pressed
+   *  on a focusable item
+   * 
+   */
+  keyDown(event) {
+    if (event.key == 'Enter') {
+      this._toggleModifications();
+    }
+  }
+
   /**
    * Toggle the modifications flag when selecting the modifications icon
    */
   _toggleModifications() {
+
     this._modificationsSelected = !this._modificationsSelected;
   }
 }

--- a/src/app/components/StandardSlot.jsx
+++ b/src/app/components/StandardSlot.jsx
@@ -35,6 +35,13 @@ export default class StandardSlot extends TranslatedComponent {
   constructor(props) {
     super(props);
     this._modificationsSelected = false;
+    this._keyDown = this._keyDown.bind(this);
+  }
+
+  _keyDown(event) {
+    if (event.key == 'Enter') {
+      this.props.onOpen(event);
+    }
   }
 
   /**
@@ -97,7 +104,7 @@ export default class StandardSlot extends TranslatedComponent {
     }
 
     return (
-      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onContextMenu={stopCtxPropagation} tabIndex="0">
+      <div className={cn('slot', { selected: this.props.selected })} onClick={this.props.onOpen} onKeyDown={this._keyDown} onContextMenu={stopCtxPropagation} tabIndex="0">
         <div className={cn('details-container', { warning: warning && warning(slot.m), disabled: m.grp !== 'bh' && !slot.enabled })}>
           <div className={'sz'}>{m.grp == 'bh' ? m.name.charAt(0) : slot.maxClass}</div>
           <div>

--- a/src/less/slot.less
+++ b/src/less/slot.less
@@ -41,6 +41,10 @@
     overflow: hidden;
   }
 
+  input.cb:focus {
+    border-color:#fff;
+  }
+
   .l {
     text-transform: capitalize;
     margin-right: 0.8em;


### PR DESCRIPTION
Added improved keyboard and focus handling for modifications sections:

1. Tab, Shift-Tab, and Enter key handling
2. keep keyboard focus inside modifications menus while open.
3. Set focus to modification gear icon when mod menu is closed
4. Set focus to slot element when module selections menu is closed.
5. Fix for Number editor values being recalculated after blur event, even if user didn't make changes to the values.
6. Fix for empty modifications menu appearing when selecting a modification which has no specials available.