### PR TITLE
Clone coriolis-data into Travis before npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
   directories:
     - node_modules
 
-before_script:
+before_install:
+  - git clone https://github.com/EDCD/coriolis-data.git ../coriolis-data
 
 script:
   - npm run lint


### PR DESCRIPTION
Travis builds have been failing since [Nov 7, 2017](https://github.com/EDCD/coriolis/commit/94d06e40254d6b171ceeb0063421899adf9a9fed), where linting and tests both started failing. The [subsequent commit](https://github.com/EDCD/coriolis/commit/0d6aa87e89f9529db7e8f35ff7b4743cedb94bd6), which changed `package.json` to use `../coriolis-data` instead of `EDCD/coriolis-data`, has left Travis builds in error state ever since. That's because npm doesn't see `coriolis-data` in the parent directory (unsurprisingly).

This PR will fix the npm install issue. You'll see [in the corresponding Travis build](https://travis-ci.org/BenJuan26/coriolis/builds/389263167) that the npm install error has been masking **503 linting errors** and 6 failed tests. Those will have to be fixed outside of this PR.