### PR TITLE
Resetting special effects for blueprints now re-calculates all stats

### DIFF
--- a/src/app/shipyard/Ship.js
+++ b/src/app/shipyard/Ship.js
@@ -484,10 +484,7 @@ export default class Ship {
    * @param  {Object} m      The module for which to clear the blueprint
    */
   clearModuleSpecial(m) {
-    if (m.blueprint) {
-      m.blueprint.special = null;
-    }
-    this.recalculateDps().recalculateHps().recalculateEps();
+    this.setModuleSpecial(m, null);
   }
 
   /**


### PR DESCRIPTION
Before this change, removing a blueprints special effect would not update all numbers properly. E. g. look at [this build](https://coriolis.edcd.io/outfit/cobra_mk_iii?code=A2pataFalddasdf4----04-45-----.Iw1%2FkA%3D%3D.Aw1%2FkA%3D%3D.H4sIAAAAAAAAA%2BP558rAwPCXFUj8mQMk%2BO8AmUIGpQwMEkc4GRjkBSIZGP7%2FZwAA3QJ2licAAAA%3D.EweloBhBGA2EoFMCGBzANokMK6A%3D).

If you remove the super capacitors special effect from the build above, nothing will change. My PR fixes that as it maps `clearModuleSpecial` to `setModuleSpecial(m, null)`.