### PR TITLE
Fixes for shieldboost mods and special effects on shield booster

### DIFF
--- a/src/app/shipyard/Module.js
+++ b/src/app/shipyard/Module.js
@@ -145,6 +145,8 @@ export default class Module {
             result = result + modValue;
           } else if (modification.method === 'overwrite') {
             result = modValue;
+          } else if (name === 'shieldboost') {
+            result = (1 + result) * (1 + modValue) - 1;
           } else {
             result = result * (1 + modValue);
           }

--- a/src/app/utils/BlueprintFunctions.js
+++ b/src/app/utils/BlueprintFunctions.js
@@ -294,21 +294,6 @@ export function getBlueprint(name, module) {
     return {};
   }
   const blueprint = JSON.parse(JSON.stringify(found));
-  if (module) {
-    if (module.grp === 'sb') {
-      // Shield boosters are treated internally as straight modifiers, so rather than (for example)
-      // being a 4% boost they are a 104% multiplier.  We need to fix the values here so that they look
-      // accurate as per the information in Elite
-      for (const grade in blueprint.grades) {
-        for (const feature in blueprint.grades[grade].features) {
-          if (feature === 'shieldboost') {
-            blueprint.grades[grade].features[feature][0] = ((1 + blueprint.grades[grade].features[feature][0]) * (1 + module.shieldboost) - 1) / module.shieldboost - 1;
-            blueprint.grades[grade].features[feature][1] = ((1 + blueprint.grades[grade].features[feature][1]) * (1 + module.shieldboost) - 1) / module.shieldboost - 1;
-          }
-        }
-      }
-    }
-  }
   return blueprint;
 }
 
@@ -387,7 +372,9 @@ export function getPercent(m) {
 
     let value = _getValue(m, featureName);
     let mult;
-    if (Modifications.modifications[featureName].higherbetter) {
+    if (featureName == 'shieldboost') {
+      mult = ((1 + value) * (1 + m.shieldboost)) - 1 - m.shieldboost;
+    } else if (Modifications.modifications[featureName].higherbetter) {
       // Higher is better, but is this making it better or worse?
       if (features[featureName][0] < 0 || (features[featureName][0] === 0 && features[featureName][1] < 0)) {
         mult = Math.round((value - features[featureName][1]) / (features[featureName][0] - features[featureName][1]) * 100);


### PR DESCRIPTION
There are two changes in this PR. Firstly, we don't change the blueprint values for shield boost effects and rather apply the mod to `1+shield booster boost` which leads to numbers that are better aligned with what is displayed ingame and especially inara.

Secondly, special effects for shield boost mods are applied correctly.

Closes #323 