### PR TITLE
No special treatment for shotspeed modifications anymore

### DIFF
--- a/src/app/shipyard/Module.js
+++ b/src/app/shipyard/Module.js
@@ -741,16 +741,6 @@ export default class Module {
    * @return {string} the shot speed for this module
    */
   getShotSpeed() {
-    if (this.blueprint && (this.blueprint.name === 'Focused' || this.blueprint.name === 'Long range')) {
-      // If the modification is focused or long range then the shot speed
-      // uses the range modifier
-      const rangemod = this.getModValue('range') / 10000;
-      let result = this['shotspeed'];
-      if (!result) {
-        return null;
-      }
-      return result * (1 + rangemod);
-    }
     return this._getModifiedValue('shotspeed');
   }
 


### PR DESCRIPTION
Shot speed now does not consider special blueprints differently. In my eyes, this was totally unnecessary. However, this PR requires https://github.com/EDCD/coriolis-data/pull/40 to work properly.