### PR TITLE
Offence table improved (+Bug fix)

### DIFF
--- a/src/app/components/Offence.jsx
+++ b/src/app/components/Offence.jsx
@@ -154,11 +154,13 @@ export default class Offence extends TranslatedComponent {
     let thermalArmourSDps = 0;
 
     let totalSEps = 0;
+    let totalSDps = 0;
 
     const rows = [];
     for (let i = 0; i < damage.length; i++) {
       const weapon = damage[i];
 
+      totalSDps += weapon.sdps.base.total;
       totalSEps += weapon.seps;
       absoluteShieldsSDps += weapon.sdps.shields.absolute;
       explosiveShieldsSDps += weapon.sdps.shields.explosive;
@@ -173,6 +175,12 @@ export default class Offence extends TranslatedComponent {
       effectivenessShieldsTooltipDetails.push(<div key='range'>{translate('range') + ' ' + formats.pct1(weapon.effectiveness.shields.range)}</div>);
       effectivenessShieldsTooltipDetails.push(<div key='resistance'>{translate('resistance') + ' ' + formats.pct1(weapon.effectiveness.shields.resistance)}</div>);
       effectivenessShieldsTooltipDetails.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.pct1(weapon.effectiveness.shields.sys)}</div>);
+
+      const baseSDpsTooltipDetails = [];
+      if (weapon.sdps.shields.absolute) baseSDpsTooltipDetails.push(<div key='absolute'>{translate('absolute') + ' ' + formats.f1(weapon.sdps.base.absolute)}</div>);
+      if (weapon.sdps.shields.explosive) baseSDpsTooltipDetails.push(<div key='explosive'>{translate('explosive') + ' ' + formats.f1(weapon.sdps.base.explosive)}</div>);
+      if (weapon.sdps.shields.kinetic) baseSDpsTooltipDetails.push(<div key='kinetic'>{translate('kinetic') + ' ' + formats.f1(weapon.sdps.base.kinetic)}</div>);
+      if (weapon.sdps.shields.thermal) baseSDpsTooltipDetails.push(<div key='thermal'>{translate('thermal') + ' ' + formats.f1(weapon.sdps.base.thermal)}</div>);
 
       const effectiveShieldsSDpsTooltipDetails = [];
       if (weapon.sdps.shields.absolute) effectiveShieldsSDpsTooltipDetails.push(<div key='absolute'>{translate('absolute') + ' ' + formats.f1(weapon.sdps.shields.absolute)}</div>);
@@ -199,6 +207,7 @@ export default class Offence extends TranslatedComponent {
             {weapon.classRating} {translate(weapon.name)}
             {weapon.engineering ? ' (' + weapon.engineering + ')' : null }
           </td>
+          <td className='ri'><span onMouseOver={termtip.bind(null, baseSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.base.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectiveShieldsSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.shields.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectivenessShieldsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.pct1(weapon.effectiveness.shields.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectiveArmourSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.armour.total)}</span></td>
@@ -231,10 +240,12 @@ export default class Offence extends TranslatedComponent {
           <thead>
           <tr className='main'>
             <th rowSpan='2' className='sortable' onClick={sortOrder.bind(this, 'n')}>{translate('weapon')}</th>
+            <th colSpan='1'>{translate('overall')}</th>
             <th colSpan='2'>{translate('opponent\'s shields')}</th>
             <th colSpan='2'>{translate('opponent\'s armour')}</th>
           </tr>
           <tr>
+            <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_SHIELDS')} onMouseOut={tooltip.bind(null, null)} onClick={sortOrder.bind(this, 'esdpss')}>{'sdps'}</th>
             <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_SHIELDS')} onMouseOut={tooltip.bind(null, null)} onClick={sortOrder.bind(this, 'esdpss')}>{'sdps'}</th>
             <th className='sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVENESS_SHIELDS')} onMouseOut={tooltip.bind(null, null)}onClick={sortOrder.bind(this, 'es')}>{'eft'}</th>
             <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_ARMOUR')} onMouseOut={tooltip.bind(null, null)}onClick={sortOrder.bind(this, 'esdpsh')}>{'sdps'}</th>
@@ -243,6 +254,12 @@ export default class Offence extends TranslatedComponent {
           </thead>
           <tbody>
             {rows}
+            <td></td>
+            <td className='ri'><span>={formats.f1(totalSDps)}</span></td>
+            <td className='ri'><span>={formats.f1(totalShieldsSDps)}</span></td>
+            <td></td>
+            <td className='ri'><span>={formats.f1(totalArmourSDps)}</span></td>
+            <td></td>
           </tbody>
         </table>
         </div>

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -819,6 +819,13 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
   const weapon = {
     eps: 0,
     damage: {
+      base: {
+        absolute: 0,
+        explosive: 0,
+        kinetic: 0,
+        thermal: 0,
+        total: 0,
+      },
       shields: {
         absolute: 0,
         explosive: 0,
@@ -862,6 +869,12 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
     weapon.effectiveness.shields.range = weapon.effectiveness.armour.range = dropoff;
     sDps *= dropoff;
   }
+
+  weapon.damage.base.absolute = sDps * m.getDamageDist().A;
+  weapon.damage.base.explosive = sDps * m.getDamageDist().E;
+  weapon.damage.base.kinetic = sDps * m.getDamageDist().K;
+  weapon.damage.base.thermal = sDps * m.getDamageDist().T;
+  weapon.damage.base.total = sDps;
 
   // Piercing/hardness modifier (for armour only)
   const armourMultiple = m.getPiercing() >= opponent.hardness ? 1 : m.getPiercing() / opponent.hardness;

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -484,7 +484,7 @@ export function shieldMetrics(ship, sys) {
     let sgSbExplosiveDmg = diminishDamageMult(sgExplosiveDmg * 0.7, (1 - shieldGenerator.getExplosiveResistance()) * boosterExplDmg);
     shield.explosive = {
       generator: sgExplosiveDmg,
-      boosters: sgSbExplosiveDmg - sgExplosiveDmg,
+      boosters: sgSbExplosiveDmg / sgExplosiveDmg,
       sys: (1 - sysResistance),
       total: sgSbExplosiveDmg * (1 - sysResistance),
       max: sgSbExplosiveDmg * (1 - maxSysResistance),
@@ -495,7 +495,7 @@ export function shieldMetrics(ship, sys) {
     let sgSbKineticDmg = diminishDamageMult(sgKineticDmg * 0.7, (1 - shieldGenerator.getKineticResistance()) * boosterKinDmg);
     shield.kinetic = {
       generator: sgKineticDmg,
-      boosters: sgSbKineticDmg - sgKineticDmg,
+      boosters: sgSbKineticDmg / sgKineticDmg,
       sys: (1 - sysResistance),
       total: sgSbKineticDmg * (1 - sysResistance),
       max: sgSbKineticDmg * (1 - maxSysResistance),
@@ -506,7 +506,7 @@ export function shieldMetrics(ship, sys) {
     let sgSbThermalDmg = diminishDamageMult(sgThermalDmg * 0.7, (1 - shieldGenerator.getThermalResistance()) * boosterThermDmg);
     shield.thermal = {
       generator: sgThermalDmg,
-      boosters: sgSbThermalDmg - sgThermalDmg,
+      boosters: sgSbThermalDmg / sgThermalDmg,
       sys: (1 - sysResistance),
       total: sgSbThermalDmg * (1 - sysResistance),
       max: sgSbThermalDmg * (1 - maxSysResistance),
@@ -612,7 +612,7 @@ export function armourMetrics(ship) {
   let armourReinforcedExplDmg = diminishDamageMult(0.7, (1 - ship.bulkheads.m.getExplosiveResistance()) * hullExplDmg);
   armour.explosive = {
     bulkheads: armourExplDmg,
-    reinforcement: armourReinforcedExplDmg - armourExplDmg,
+    reinforcement: armourReinforcedExplDmg / armourExplDmg,
     total: armourReinforcedExplDmg,
     res: 1 - armourReinforcedExplDmg
   };
@@ -621,7 +621,7 @@ export function armourMetrics(ship) {
   let armourReinforcedKinDmg = diminishDamageMult(0.7, (1 - ship.bulkheads.m.getKineticResistance()) * hullKinDmg);
   armour.kinetic = {
     bulkheads: armourKinDmg,
-    reinforcement: armourReinforcedKinDmg - armourKinDmg,
+    reinforcement: armourReinforcedKinDmg / armourKinDmg,
     total: armourReinforcedKinDmg,
     res: 1 - armourReinforcedKinDmg
   };
@@ -630,7 +630,7 @@ export function armourMetrics(ship) {
   let armourReinforcedThermDmg = diminishDamageMult(0.7, (1 - ship.bulkheads.m.getThermalResistance()) * hullThermDmg);
   armour.thermal = {
     bulkheads: armourThermDmg,
-    reinforcement: armourReinforcedThermDmg - armourThermDmg,
+    reinforcement: armourReinforcedThermDmg / armourThermDmg,
     total: armourReinforcedThermDmg,
     res: 1 - armourReinforcedThermDmg
   };


### PR DESCRIPTION
Two changes:
1. The offence table now lists "native" SDPS values and has an aggregation row at the bottom (see screenshot below)
2. https://github.com/EDCD/coriolis/commit/3febe465f68af433643aa40a9c5e7984ad97e4a6 fixes a bug that was introduced in a8c44fddcae97c7cef1d99b52d4a2009b2c0b029 and d2380a5c9c091ad5deca0a70c959fc10171bbf5b. There, I set the `reinforcement`/`booster` value to be calculated by difference. However, it is expected to be calculated as multiplier in https://github.com/EDCD/coriolis/blob/master/src/app/shipyard/Calculations.js#L876 ff. Other references are not influenced by this change. This leads to effectiveness values being shown correctly. Before they were in the range `[-100%, 0%]`.

Closes #283 

![image](https://user-images.githubusercontent.com/9728715/44315322-4d26d000-a423-11e8-9abb-0ae5fd4173f7.png)
