### PR TITLE
Shield defence proportions calculated correctly

### DIFF
--- a/src/app/components/Defence.jsx
+++ b/src/app/components/Defence.jsx
@@ -102,19 +102,19 @@ export default class Defence extends TranslatedComponent {
 
         // Add effective shield from resistances
         const rawMj = shield.generator + shield.boosters + shield.cells;
-        const explosiveMj = rawMj / shield.explosive.total - rawMj;
+        const explosiveMj = rawMj / (shield.explosive.base) - rawMj;
         if (explosiveMj != 0) effectiveShieldExplosiveTt.push(<div key='resistance'>{translate('resistance') + ' ' + formats.int(explosiveMj)}{units.MJ}</div>);
-        const kineticMj = rawMj / shield.kinetic.total - rawMj;
+        const kineticMj = rawMj / (shield.kinetic.base) - rawMj;
         if (kineticMj != 0) effectiveShieldKineticTt.push(<div key='resistance'>{translate('resistance') + ' ' + formats.int(kineticMj)}{units.MJ}</div>);
-        const thermalMj = rawMj / shield.thermal.total - rawMj;
+        const thermalMj = rawMj / (shield.thermal.base) - rawMj;
         if (thermalMj != 0) effectiveShieldThermalTt.push(<div key='resistance'>{translate('resistance') + ' ' + formats.int(thermalMj)}{units.MJ}</div>);
 
         // Add effective shield from power distributor SYS pips
         if (shield.absolute.sys != 1) {
-          effectiveShieldAbsoluteTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.absolute.sys - rawMj)}{units.MJ}</div>);
-          effectiveShieldExplosiveTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.explosive.sys - rawMj)}{units.MJ}</div>);
-          effectiveShieldKineticTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.kinetic.sys - rawMj)}{units.MJ}</div>);
-          effectiveShieldThermalTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.thermal.sys - rawMj)}{units.MJ}</div>);
+          effectiveShieldAbsoluteTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.absolute.total - rawMj)}{units.MJ}</div>);
+          effectiveShieldExplosiveTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.explosive.total - rawMj / shield.explosive.base)}{units.MJ}</div>);
+          effectiveShieldKineticTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.kinetic.total - rawMj / shield.kinetic.base)}{units.MJ}</div>);
+          effectiveShieldThermalTt.push(<div key='power distributor'>{translate('power distributor') + ' ' + formats.int(rawMj / shield.thermal.total - rawMj / shield.thermal.base)}{units.MJ}</div>);
         }
       }
 

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -480,8 +480,25 @@ export function shieldMetrics(ship, sys) {
       max: 1 - maxSysResistance
     };
 
+    /**
+     * An object that stores a selection of difference damage multipliers that
+     * deal with a ship's shield strength.
+     * @typedef {Object} ShieldDamageMults
+     * @property {number} generator Base damage multiplier of the shield
+     * contributing it's base resistance.
+     * @property {number} boosters Damage multiplier contributed by all
+     * boosters, i.e. `rawMj / (generator * boosters)` equals shield strength
+     * with 0 pips to sys.
+     * @property {number} sys Damage multiplier contributed by pips to sys.
+     * @property {number} base Damage multiplier with 0 pips to sys; just
+     * boosters and shield generator. Equals `generator * boosters`.
+     * @property {number} total Damage multiplier with current pip settings.
+     * @property {number} max Damage multiplier with 4 pips to sys.
+     */
+
     let sgExplosiveDmg = 1 - shieldGenerator.getExplosiveResistance();
     let sgSbExplosiveDmg = diminishDamageMult(sgExplosiveDmg * 0.7, (1 - shieldGenerator.getExplosiveResistance()) * boosterExplDmg);
+    /** @type {ShieldDamageMults} */
     shield.explosive = {
       generator: sgExplosiveDmg,
       boosters: sgSbExplosiveDmg - sgExplosiveDmg,
@@ -493,6 +510,7 @@ export function shieldMetrics(ship, sys) {
 
     let sgKineticDmg = 1 - shieldGenerator.getKineticResistance();
     let sgSbKineticDmg = diminishDamageMult(sgKineticDmg * 0.7, (1 - shieldGenerator.getKineticResistance()) * boosterKinDmg);
+    /** @type {ShieldDamageMults} */
     shield.kinetic = {
       generator: sgKineticDmg,
       boosters: sgSbKineticDmg - sgKineticDmg,
@@ -504,6 +522,7 @@ export function shieldMetrics(ship, sys) {
 
     let sgThermalDmg = 1 - shieldGenerator.getThermalResistance();
     let sgSbThermalDmg = diminishDamageMult(sgThermalDmg * 0.7, (1 - shieldGenerator.getThermalResistance()) * boosterThermDmg);
+    /** @type {ShieldDamageMults} */
     shield.thermal = {
       generator: sgThermalDmg,
       boosters: sgSbThermalDmg - sgThermalDmg,

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -486,6 +486,7 @@ export function shieldMetrics(ship, sys) {
       generator: sgExplosiveDmg,
       boosters: sgSbExplosiveDmg - sgExplosiveDmg,
       sys: (1 - sysResistance),
+      base: sgSbExplosiveDmg,
       total: sgSbExplosiveDmg * (1 - sysResistance),
       max: sgSbExplosiveDmg * (1 - maxSysResistance),
     };
@@ -496,6 +497,7 @@ export function shieldMetrics(ship, sys) {
       generator: sgKineticDmg,
       boosters: sgSbKineticDmg - sgKineticDmg,
       sys: (1 - sysResistance),
+      base: sgSbKineticDmg,
       total: sgSbKineticDmg * (1 - sysResistance),
       max: sgSbKineticDmg * (1 - maxSysResistance),
     };
@@ -506,6 +508,7 @@ export function shieldMetrics(ship, sys) {
       generator: sgThermalDmg,
       boosters: sgSbThermalDmg - sgThermalDmg,
       sys: (1 - sysResistance),
+      base: sgSbThermalDmg,
       total: sgSbThermalDmg * (1 - sysResistance),
       max: sgSbThermalDmg * (1 - maxSysResistance),
     };

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -488,7 +488,6 @@ export function shieldMetrics(ship, sys) {
       sys: (1 - sysResistance),
       total: sgSbExplosiveDmg * (1 - sysResistance),
       max: sgSbExplosiveDmg * (1 - maxSysResistance),
-      res: 1 - sgSbExplosiveDmg
     };
 
     let sgKineticDmg = 1 - shieldGenerator.getKineticResistance();
@@ -499,7 +498,6 @@ export function shieldMetrics(ship, sys) {
       sys: (1 - sysResistance),
       total: sgSbKineticDmg * (1 - sysResistance),
       max: sgSbKineticDmg * (1 - maxSysResistance),
-      res: 1 - sgSbKineticDmg
     };
 
     let sgThermalDmg = 1 - shieldGenerator.getThermalResistance();
@@ -510,7 +508,6 @@ export function shieldMetrics(ship, sys) {
       sys: (1 - sysResistance),
       total: sgSbThermalDmg * (1 - sysResistance),
       max: sgSbThermalDmg * (1 - maxSysResistance),
-      res: 1 - sgSbThermalDmg
     };
   }
   return shield;


### PR DESCRIPTION
Before this PR, in the defence panel when looking at the values that make up total effective shield strength, the resistance value would already contain sys-contributed MJ. See screenshot below.

Now everything works correct.

![image](https://user-images.githubusercontent.com/9728715/44316453-0093c280-a42c-11e8-86dc-9d8d3a89972a.png)
