### PR TITLE
Fixed resize observer loop limit exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "less": "^2.7.2",
     "less-loader": "^4.0.3",
     "react-addons-perf": "^15.4.2",
-    "react-measure": "^1.4.7",
+    "react-container-dimensions": "^1.4.1",
     "react-testutils-additions": "^15.2.0",
     "react-transition-group": "^1.1.2",
     "rimraf": "^2.6.1",

--- a/src/app/components/PieChart.jsx
+++ b/src/app/components/PieChart.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Measure from 'react-measure';
+import ContainerDimensions from 'react-container-dimensions';
 import * as d3 from 'd3';
 
 const CORIOLIS_COLOURS = ['#FF8C0D', '#1FB0FF', '#71A052', '#D5D54D'];
@@ -27,13 +27,6 @@ export default class PieChart extends Component {
     this.colors = CORIOLIS_COLOURS;
     this.arc = d3.arc();
     this.arc.innerRadius(0);
-
-    this.state = {
-      dimensions: {
-        width: 100,
-        height: 100
-      }
-    };
   }
 
 
@@ -41,15 +34,15 @@ export default class PieChart extends Component {
    * Generate a slice of the pie chart
    * @param {Object} d     the data for this slice
    * @param {number} i     the index of this slice
+   * @param {number} width the current width of the parent container
    * @returns {Object}     the SVG for the slice
    */
-  sliceGenerator(d, i) {
+  sliceGenerator(d, i, width) {
     if (!d || d.value == 0) {
       // Ignore 0 values
       return null;
     }
 
-    const { width, height } = this.state.dimensions;
     const { data } = this.props;
 
     // Push the labels further out from the centre of the slice
@@ -76,22 +69,24 @@ export default class PieChart extends Component {
    * @returns {object} Markup
    */
   render() {
-    const { width, height } = this.state.dimensions;
-    const pie = this.pie(this.props.data),
-        translate = `translate(${width / 2}, ${width * 0.4})`; 
-
-    this.arc.outerRadius(width * 0.4);
-
     return (
-      <Measure width='100%' whitelist={['width', 'top']} onMeasure={ (dimensions) => { this.setState({ dimensions }); }}>
-        <div width={width} height={width}>
-          <svg style={{ stroke: 'None' }} width={width} height={width * 0.9}>
-            <g transform={translate}>
-              {pie.map((d, i) => this.sliceGenerator(d, i))}
-            </g>
-          </svg>
-        </div>
-      </Measure>
+      <ContainerDimensions>
+        { ({ width }) => {
+          const pie = this.pie(this.props.data),
+              translate = `translate(${width / 2}, ${width * 0.4})`;
+
+          this.arc.outerRadius(width * 0.4);
+          return (
+            <div width={width} height={width}>
+              <svg style={{ stroke: 'None' }} width={width} height={width * 0.9}>
+                <g transform={translate}>
+                  {pie.map((d, i) => this.sliceGenerator(d, i, width))}
+                </g>
+              </svg>
+            </div>
+          );
+        }}
+      </ContainerDimensions>
     );
   }
 }

--- a/src/app/components/VerticalBarChart.jsx
+++ b/src/app/components/VerticalBarChart.jsx
@@ -1,6 +1,6 @@
 import TranslatedComponent from './TranslatedComponent';
 import React, { PropTypes } from 'react';
-import Measure from 'react-measure';
+import ContainerDimensions from 'react-container-dimensions';
 import { BarChart, Bar, XAxis, YAxis } from 'recharts';
 
 const CORIOLIS_COLOURS = ['#FF8C0D', '#1FB0FF', '#71A052', '#D5D54D'];
@@ -32,13 +32,6 @@ export default class VerticalBarChart extends TranslatedComponent {
     super(props);
 
     this._termtip = this._termtip.bind(this);
-
-    this.state = {
-      dimensions: {
-        width: 300,
-        height: 300
-      }
-    };
   }
 
   /**
@@ -46,7 +39,6 @@ export default class VerticalBarChart extends TranslatedComponent {
    * @returns {Object} the markup
    */
   render() {
-    const { width, height } = this.state.dimensions;
     const { tooltip, termtip } = this.context;
 
     // Calculate maximum for Y
@@ -56,15 +48,17 @@ export default class VerticalBarChart extends TranslatedComponent {
     const localMax = Math.max(dataMax, yMax);
 
     return (
-      <Measure whitelist={['width', 'top']} onMeasure={ (dimensions) => this.setState({ dimensions }) }>
-        <div width='100%'>
-          <BarChart width={width} height={width * ASPECT} data={this.props.data} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
-            <XAxis interval={0} fontSize='0.8em' stroke={AXIS_COLOUR} dataKey='label' />
-            <YAxis interval={'preserveStart'} tickCount={11} fontSize='0.8em' stroke={AXIS_COLOUR} type='number' domain={[0, localMax]}/>
-            <Bar dataKey='value' label={<ValueLabel />} fill={CORIOLIS_COLOURS[0]} isAnimationActive={false} onMouseOver={this._termtip} onMouseOut={tooltip.bind(null, null)}/>
-          </BarChart>
-        </div>
-      </Measure>
+      <ContainerDimensions>
+        { ({ width }) => (
+          <div width='100%'>
+            <BarChart width={width} height={width * ASPECT} data={this.props.data} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+              <XAxis interval={0} fontSize='0.8em' stroke={AXIS_COLOUR} dataKey='label' />
+              <YAxis interval={'preserveStart'} tickCount={11} fontSize='0.8em' stroke={AXIS_COLOUR} type='number' domain={[0, localMax]}/>
+              <Bar dataKey='value' label={<ValueLabel />} fill={CORIOLIS_COLOURS[0]} isAnimationActive={false} onMouseOver={this._termtip} onMouseOut={tooltip.bind(null, null)}/>
+            </BarChart>
+          </div>
+        )}
+      </ContainerDimensions>
     );
   }
 

--- a/src/app/components/WeaponDamageChart.jsx
+++ b/src/app/components/WeaponDamageChart.jsx
@@ -74,7 +74,7 @@ export default class WeaponDamageChart extends TranslatedComponent {
    * Calculate the maximum range of a ship's weapons
    * @param   {Object}  ship     The ship
    * @returns {int}              The maximum range, in metres
-   */ 
+   */
   _calcMaxRange(ship) {
     let maxRange = 1000; // Minimum
     for (let i = 0; i < ship.hardpoints.length; i++) {
@@ -184,7 +184,7 @@ export default class WeaponDamageChart extends TranslatedComponent {
     const code = `${ship.toString()}:${opponent.toString()}`;
 
     return (
-      <span>
+      <div>
         <LineChart
           xMax={maxRange}
           yMax={this.state.maxDps}
@@ -198,7 +198,7 @@ export default class WeaponDamageChart extends TranslatedComponent {
           points={200}
           code={code}
         />
-      </span>
+      </div>
     );
   }
 }


### PR DESCRIPTION
I fixed issue #208 by changing a dependency. @willyb321 your guess seems to be right that this issue was caused by `react-measure`. I therefore removed this dependency and added `react-container-dimensions`. This behaves nearly identical however it's approach is a bit more cleaner in my opinion as it doesn't rely on calbacks, etc.

In consequence I needed to use a `<div>` in the `WeaponDamageChart` as that dependency does not seem to work with `<span>`. I couldn't spot a change in the UI therefore I think this is fine.

You might need to update the `package-lock.json`.

Closes #208 