### PR TITLE
Enhance number editing

### DIFF
--- a/src/app/components/Modification.jsx
+++ b/src/app/components/Modification.jsx
@@ -39,10 +39,24 @@ export default class Modification extends TranslatedComponent {
    *                       in a value by hand
    */
   _updateValue(value) {
-    let { m, name, ship } = this.props;
-    value = Math.max(Math.min(value, 50000), -50000);
-    ship.setModification(m, name, value, true, true);
     this.setState({ value });
+    let reCast = String(Number(value));
+    if (reCast.endsWith(value) || reCast.startsWith(value)) {
+      let { m, name, ship } = this.props;
+      value = Math.max(Math.min(value, 50000), -50000);
+      ship.setModification(m, name, value, true, true);
+    }
+  }
+
+  /**
+   * Triggered when a key is pressed down with focus on the number editor.
+   * @param {SyntheticEvent} event Key down event
+   */
+  _keyDown(event) {
+    if (event.key == 'Enter') {
+      this._updateFinished();
+    }
+    this.props.onKeyDown(event);
   }
 
   /**
@@ -91,7 +105,7 @@ export default class Modification extends TranslatedComponent {
                   {this.props.editable ?
                     <NumberEditor className={cn(inputClassNames)} value={this.state.value}
                       decimals={2} style={{ textAlign: 'right' }} step={0.01}
-                      stepModifier={1} onKeyDown={ this.props.onKeyDown }
+                      stepModifier={1} onKeyDown={this._keyDown.bind(this)}
                       onValueChange={this._updateValue.bind(this)} /> :
                     <input type="text" value={formats.f2(this.state.value)}
                       disabled className={cn('number-editor', 'greyed-out')}


### PR DESCRIPTION
References #401

Key change can be found in line 44 where I only set values to the module when we (kind of) can recreate the string entered. This should prevent `1.` to be set to `1`. In that case the script wouldn't set the value as number because it would recognize `1` not being a pre- or suffix of `1.`.

Also pressing Enter commits changes now.