### PR TITLE
448: compare highlights in shipyard

### DIFF
--- a/src/app/pages/Page.jsx
+++ b/src/app/pages/Page.jsx
@@ -51,19 +51,6 @@ export default class Page extends React.Component {
   }
 
   /**
-   * Pages are 'pure' components that only render when props, state, or context changes.
-   * This method performs a shallow comparison to determine change.
-   *
-   * @param  {Object} np  Next/Incoming properties
-   * @param  {Object} ns  Next/Incoming state
-   * @param  {Object} nc  Next/Incoming context
-   * @return {Boolean}    True if props, state, or context has changed
-   */
-  shouldComponentUpdate(np, ns, nc) {
-    return !shallowEqual(this.props, np) || !shallowEqual(this.state, ns) || !shallowEqual(this.context, nc);
-  }
-
-  /**
    * Update the window title upon mount
    */
   componentWillMount() {

--- a/src/app/pages/ShipyardPage.jsx
+++ b/src/app/pages/ShipyardPage.jsx
@@ -126,18 +126,29 @@ export default class ShipyardPage extends Page {
       title: 'Coriolis EDCD Edition - Shipyard',
       shipPredicate: 'name',
       shipDesc: true,
-      shipSummaries: ShipyardPage.cachedShipSummaries
+      shipSummaries: ShipyardPage.cachedShipSummaries,
+      compare: {},
     };
   }
 
   /**
-   * Higlight the current ship in the table
+   * Higlight the current ship in the table on mouse over
    * @param  {String} shipId Ship Id
    * @param  {SyntheticEvent} event  Event
    */
   _highlightShip(shipId, event) {
     event.stopPropagation();
     this.setState({ shipId });
+  }
+
+  /**
+   * Toggle compare highlighting for ships in the table
+   * @param {String} shipId Ship Id
+   */
+  _toggleCompare(shipId) {
+    let compare = this.state.compare;
+    compare[shipId] = !compare[shipId];
+    this.setState({ compare });
   }
 
   /**
@@ -180,8 +191,10 @@ export default class ShipyardPage extends Page {
         style={{ height: '1.5em' }}
         className={cn({
           highlighted: noTouch && this.state.shipId === s.id,
+          "compare-highlight": this.state.compare[s.id],
         })}
         onMouseEnter={noTouch && this._highlightShip.bind(this, s.id)}
+        onClick={() => this._toggleCompare(s.id)}
       >
         <td className="ri">{s.manufacturer}</td>
         <td className="ri">{fInt(s.retailCost)}</td>
@@ -298,8 +311,10 @@ export default class ShipyardPage extends Page {
           style={{ height: '1.5em' }}
           className={cn({
             highlighted: noTouch && this.state.shipId === s.id,
+            "compare-highlight": this.state.compare[s.id],
           })}
           onMouseEnter={noTouch && this._highlightShip.bind(this, s.id)}
+          onClick={() => this._toggleCompare(s.id)}
         >
           <td className="le">
             <Link href={'/outfit/' + s.id}>{s.name} {s.beta === true ? '(Beta)' : null}</Link>
@@ -321,7 +336,7 @@ export default class ShipyardPage extends Page {
             maxWidth: '100%'
           }}
         >
-          <table style={{ width: '12em', position: 'absolute', zIndex: 1 }}>
+          <table style={{ width: '12em', position: 'absolute', zIndex: 1 }} className="shipyard-table">
             <thead>
               <tr>
                 <th className="le rgt">&nbsp;</th>
@@ -340,7 +355,7 @@ export default class ShipyardPage extends Page {
             </tbody>
           </table>
           <div style={{ overflowX: 'scroll', maxWidth: '100%' }}>
-            <table style={{ marginLeft: 'calc(12em - 1px)', zIndex: 0 }}>
+            <table style={{ marginLeft: 'calc(12em - 1px)', zIndex: 0 }} className="shipyard-table">
               <thead>
                 <tr className="main">
                   <th

--- a/src/app/pages/ShipyardPage.jsx
+++ b/src/app/pages/ShipyardPage.jsx
@@ -191,7 +191,7 @@ export default class ShipyardPage extends Page {
         style={{ height: '1.5em' }}
         className={cn({
           highlighted: noTouch && this.state.shipId === s.id,
-          "compare-highlight": this.state.compare[s.id],
+          comparehighlight: this.state.compare[s.id],
         })}
         onMouseEnter={noTouch && this._highlightShip.bind(this, s.id)}
         onClick={() => this._toggleCompare(s.id)}
@@ -311,7 +311,7 @@ export default class ShipyardPage extends Page {
           style={{ height: '1.5em' }}
           className={cn({
             highlighted: noTouch && this.state.shipId === s.id,
-            "compare-highlight": this.state.compare[s.id],
+            comparehighlight: this.state.compare[s.id],
           })}
           onMouseEnter={noTouch && this._highlightShip.bind(this, s.id)}
           onClick={() => this._toggleCompare(s.id)}

--- a/src/less/colors.less
+++ b/src/less/colors.less
@@ -3,6 +3,7 @@
 @disabledDarken: 15%;
 @bgTransparency: 10%;
 @bgHighlight: 5%;
+@fgHighlight: 10%;
 
 // Foreground colors
 @fg: #CCC;
@@ -26,6 +27,7 @@
 @warning-bg: fadeout(darken(@warning, @bgDarken), @bgTransparency); // Dark Red
 
 @alt-primary-bg-highlighted: lighten(@alt-primary-bg, @bgHighlight);
+@fg-highlighted: lighten(@fg, @fgHighlight);
 
 
 

--- a/src/less/colors.less
+++ b/src/less/colors.less
@@ -2,6 +2,7 @@
 @bgDarken: 40%;
 @disabledDarken: 15%;
 @bgTransparency: 10%;
+@bgHighlight: 5%;
 
 // Foreground colors
 @fg: #CCC;
@@ -21,8 +22,11 @@
 @bgBlack: #000;
 @primary-bg: fadeout(darken(@primary, 47%), 15%);
 @alt-primary-bg: fadeout(darken(@primary, 42%), 15%); // Lighter brown background
-@secondary-bg: fadeout(darken(@secondary, @bgDarken), @bgTransparency); // Brown background
+@secondary-bg: fadeout(darken(@secondary, @bgDarken), @bgTransparency); // Blue background
 @warning-bg: fadeout(darken(@warning, @bgDarken), @bgTransparency); // Dark Red
+
+@alt-primary-bg-highlighted: lighten(@alt-primary-bg, @bgHighlight);
+
 
 
 .fg {

--- a/src/less/table.less
+++ b/src/less/table.less
@@ -86,7 +86,8 @@ td {
 }
 
 table.shipyard-table{
-  tbody tr.compare-highlight{
+  tbody tr.comparehighlight{
     background-color: @secondary-bg;
+    color: @fg-highlighted;
   }
 }

--- a/src/less/table.less
+++ b/src/less/table.less
@@ -52,7 +52,7 @@ tbody tr {
   }
 
   .no-touch &.highlight:hover, .no-touch &.highlighted {
-    background-color: @warning-bg;
+    background-color: @alt-primary-bg-highlighted; //@warning-bg;
   }
 
   &:nth-child(odd){
@@ -82,5 +82,11 @@ td {
 
   &.tc {
     text-align: center;
+  }
+}
+
+table.shipyard-table{
+  tbody tr.compare-highlight{
+    background-color: @secondary-bg;
   }
 }


### PR DESCRIPTION
- Click ship rows to highlight them, for easy comparing.
- Removes a custom override for shouldComponentUpdate. My theory is that react is better suited to evaluate this natively, unless there are known performance issues. Since we don't know, give performance a test in beta. 
resolves [Issue#448](https://github.com/EDCD/coriolis/issues/448)