### PR TITLE
Feature/add dpe to offence stats

### DIFF
--- a/src/app/components/Offence.jsx
+++ b/src/app/components/Offence.jsx
@@ -243,8 +243,13 @@ export default class Offence extends TranslatedComponent {
           <td className='ri'><span onMouseOver={termtip.bind(null, baseSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.base.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectiveShieldsSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.shields.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectivenessShieldsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.pct1(weapon.effectiveness.shields.total)}</span></td>
+
+          <td className='ri'><span>{formats.f1(weapon.effectiveness.shields.dpe)}</span></td>
+
           <td className='ri'><span onMouseOver={termtip.bind(null, effectiveArmourSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.f1(weapon.sdps.armour.total)}</span></td>
           <td className='ri'><span onMouseOver={termtip.bind(null, effectivenessArmourTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>{formats.pct1(weapon.effectiveness.armour.total)}</span></td>
+
+          <td className='ri'><span>{formats.f1(weapon.effectiveness.armour.dpe)}</span></td>
         </tr>);
     }
 
@@ -271,15 +276,20 @@ export default class Offence extends TranslatedComponent {
               <tr className='main'>
                 <th rowSpan='2' className='sortable' onClick={sortOrder.bind(this, 'n')}>{translate('weapon')}</th>
                 <th colSpan='1'>{translate('overall')}</th>
-                <th colSpan='2'>{translate('opponent\'s shields')}</th>
-                <th colSpan='2'>{translate('opponent\'s armour')}</th>
+                <th colSpan='3'>{translate('opponent\'s shields')}</th>
+                <th colSpan='3'>{translate('opponent\'s armour')}</th>
               </tr>
               <tr>
                 <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_SHIELDS')} onMouseOut={tooltip.bind(null, null)} onClick={sortOrder.bind(this, 'esdpss')}>{'sdps'}</th>
                 <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_SHIELDS')} onMouseOut={tooltip.bind(null, null)} onClick={sortOrder.bind(this, 'esdpss')}>{'sdps'}</th>
                 <th className='sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVENESS_SHIELDS')} onMouseOut={tooltip.bind(null, null)}onClick={sortOrder.bind(this, 'es')}>{'eft'}</th>
+
+                <th className='sortable'>{'dpe'}</th>
+
                 <th className='lft sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVE_SDPS_ARMOUR')} onMouseOut={tooltip.bind(null, null)}onClick={sortOrder.bind(this, 'esdpsh')}>{'sdps'}</th>
                 <th className='sortable' onMouseOver={termtip.bind(null, 'TT_EFFECTIVENESS_ARMOUR')} onMouseOut={tooltip.bind(null, null)}onClick={sortOrder.bind(this, 'eh')}>{'eft'}</th>
+
+                <th className='sortable'>{'dpe'}</th> 
               </tr>
             </thead>
             <tbody>
@@ -290,7 +300,9 @@ export default class Offence extends TranslatedComponent {
                   <td className='ri'><span onMouseOver={termtip.bind(null, totalSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>={formats.f1(totalSDps)}</span></td>
                   <td className='ri'><span onMouseOver={termtip.bind(null, totalShieldsSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>={formats.f1(totalShieldsSDps)}</span></td>
                   <td></td>
+                  <td></td>
                   <td className='ri'><span onMouseOver={termtip.bind(null, totalArmourSDpsTooltipDetails)} onMouseOut={tooltip.bind(null, null)}>={formats.f1(totalArmourSDps)}</span></td>
+                  <td></td>
                   <td></td>
                 </tr>
               }

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -904,12 +904,14 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
       shields: {
         range: 1,
         sys: opponentHasShields ? opponentShields.absolute.sys : 1,
-        resistance: 1
+        resistance: 1,
+        dpe: 1
       },
       armour: {
         range: 1,
         hardness: 1,
-        resistance: 1
+        resistance: 1,
+        dpe: 1
       }
     }
   };
@@ -969,11 +971,20 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
   weapon.damage.shields.total = weapon.damage.shields.absolute + weapon.damage.shields.explosive + weapon.damage.shields.kinetic + weapon.damage.shields.thermal;
   weapon.damage.armour.total = weapon.damage.armour.absolute + weapon.damage.armour.explosive + weapon.damage.armour.kinetic + weapon.damage.armour.thermal;
 
+
+
   weapon.effectiveness.shields.resistance *= shieldsResistance;
   weapon.effectiveness.armour.resistance *= armourResistance;
 
+
   weapon.effectiveness.shields.total = weapon.effectiveness.shields.range * weapon.effectiveness.shields.sys * weapon.effectiveness.shields.resistance;
   weapon.effectiveness.armour.total = weapon.effectiveness.armour.range * weapon.effectiveness.armour.resistance * weapon.effectiveness.armour.hardness;
+
+  weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps();
+  weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getEps();
+  console.log(weapon.damage.shields.dpe);
+
+
   return weapon;
 }
 

--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -982,7 +982,6 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
 
   weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps();
   weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getEps();
-  console.log(weapon.damage.shields.dpe);
 
 
   return weapon;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/129909/88080331-d4809f00-cb76-11ea-8b78-f6b3b3e2903e.png)

This change adds Damage Per Energy into the offence table, so that the user can compare the effectiveness vs shields or armor at various ranges.