### PR TITLE
Fix DPE calculations on offense tab

### DIFF
--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -918,8 +918,8 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
   weapon.effectiveness.shields.total = weapon.effectiveness.shields.range * weapon.effectiveness.shields.sys * weapon.effectiveness.shields.resistance;
   weapon.effectiveness.armour.total = weapon.effectiveness.armour.range * weapon.effectiveness.armour.resistance * weapon.effectiveness.armour.hardness;
 
-  weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps();
-  weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getEps();
+  weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps() / m.getSustainedFactor();
+  weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getEps() / m.getSustainedFactor();
 
 
   return weapon;


### PR DESCRIPTION
The offense tab was using sustained DPS and non-sustained EPS to calculate DPE, resulting in incorrect values. This PR corrects this, and the DPE values now equal the values in the module configuration (after taking effectiveness into account).