### PR TITLE
Prevent engine pips from affecting roll and yaw

### DIFF
--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -293,7 +293,7 @@ export function calcRoll(mass, baseRoll, thrusters, engpip, eng, boostFactor, bo
   let minMul = thrusters instanceof Module ? thrusters.getMinMul('rotation') : (thrusters.minmulrotation ? thrusters.minmulrotation : thrusters.minmul);
   let optMul = thrusters instanceof Module ? thrusters.getOptMul('rotation') : (thrusters.optmulrotation ? thrusters.optmulrotation : thrusters.optmul);
   let maxMul = thrusters instanceof Module ? thrusters.getMaxMul('rotation') : (thrusters.maxmulrotation ? thrusters.maxmulrotation : thrusters.maxmul);
-
+  eng = 0;
   let result = calcValue(minMass, optMass, maxMass, minMul, optMul, maxMul, mass, baseRoll, engpip, eng);
   if (boost == true) {
     result *= boostFactor;
@@ -321,7 +321,7 @@ export function calcYaw(mass, baseYaw, thrusters, engpip, eng, boostFactor, boos
   let minMul = thrusters instanceof Module ? thrusters.getMinMul('rotation') : (thrusters.minmulrotation ? thrusters.minmulrotation : thrusters.minmul);
   let optMul = thrusters instanceof Module ? thrusters.getOptMul('rotation') : (thrusters.optmulrotation ? thrusters.optmulrotation : thrusters.optmul);
   let maxMul = thrusters instanceof Module ? thrusters.getMaxMul('rotation') : (thrusters.maxmulrotation ? thrusters.maxmulrotation : thrusters.maxmul);
-
+  eng = 0;
   let result = calcValue(minMass, optMass, maxMass, minMul, optMul, maxMul, mass, baseYaw, engpip, eng);
   if (boost == true) {
     result *= boostFactor;


### PR DESCRIPTION
![146264928-724694c7-33af-4ff7-9ddb-fde736efe3e6](https://user-images.githubusercontent.com/2429309/146469526-24fbb230-109f-4f44-91ea-dd968d5ff71b.png)

EDSY currently displays the correct speeds for Roll and Pitch, which should not be affected by ENG pips according to the current behavior of the game.

Thrust and Pitch speeds are modified by ENG pips.