### PR TITLE
Weapon Effectiveness sustained factor should be: dpe = total / (m.get…

### DIFF
--- a/src/app/shipyard/Calculations.js
+++ b/src/app/shipyard/Calculations.js
@@ -854,11 +854,12 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
     }
   };
 
-  // EPS
-  weapon.eps = m.getClip() ?  (m.getClip() * m.getEps() / m.getRoF()) / ((m.getClip() / m.getRoF()) + m.getReload()) : m.getEps();
 
   // Initial sustained DPS
   let sDps = m.getSDps();
+
+  // Initial sustained EPS
+  weapon.eps = m.getSEps();  
 
   // Take fall-off in to account
   const falloff = m.getFalloff();
@@ -918,8 +919,8 @@ export function _weaponSustainedDps(m, opponent, opponentShields, opponentArmour
   weapon.effectiveness.shields.total = weapon.effectiveness.shields.range * weapon.effectiveness.shields.sys * weapon.effectiveness.shields.resistance;
   weapon.effectiveness.armour.total = weapon.effectiveness.armour.range * weapon.effectiveness.armour.resistance * weapon.effectiveness.armour.hardness;
 
-  weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps() / m.getSustainedFactor();
-  weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getEps() / m.getSustainedFactor();
+  weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getSEps();
+  weapon.effectiveness.armour.dpe =  weapon.damage.armour.total / m.getSEps();
 
 
   return weapon;
@@ -937,7 +938,7 @@ export function timeToDrainWep(ship, wep) {
   for (let slotNum in ship.hardpoints) {
     const slot = ship.hardpoints[slotNum];
     if (slot.maxClass > 0 && slot.m && slot.enabled && slot.type === 'WEP' && slot.m.getDps()) {
-      totalSEps += slot.m.getClip() ? (slot.m.getClip() * slot.m.getEps() / slot.m.getRoF()) / ((slot.m.getClip() / slot.m.getRoF()) + slot.m.getReload()) : slot.m.getEps();
+	totalSEps += slot.m.getSEps();
     }
   }
 

--- a/src/app/shipyard/Module.js
+++ b/src/app/shipyard/Module.js
@@ -839,12 +839,30 @@ export default class Module {
   }
 
   /**
+   * Get the SDPE for this module
+   * @param {Boolean} [modified=true] Whether to take modifications into account
+   * @return {Number} The SDPE of this module
+   */
+  getSDpe(modified = true) {
+    return this.getDpe(modified) * this.getSustainedFactor(modified);
+  }
+
+  /**
    * Get the SDPS for this module
    * @param {Boolean} [modified=true] Whether to take modifications into account
    * @return {Number} The SDPS of this module
    */
   getSDps(modified = true) {
     return this.getDps(modified) * this.getSustainedFactor(modified);
+  }
+
+  /**
+   * Get the SEPS for this module
+   * @param {Boolean} [modified=true] Whether to take modifications into account
+   * @return {Number} The SEPS of this module
+   */
+  getSEps(modified = true) {
+    return this.getEps(modified) * this.getSustainedFactor(modified);
   }
 
   /**


### PR DESCRIPTION
I think we need to consider this one before merging as i'm still not 100% on how this should be done.

Issues i've tried to resolve.

- Time to drain shields/armor looked like it was double counting rate of fire, a Medium Railgun was being calculated as using almost half the energy it really consumes. You can test this by comparing time to break shields with only half a pip in weapons, the weapon with the best DPE should win, but a medium railgun currently downs the shields faster than a burst laser with better DPE.
- The recent divide by sustained factor was missing brackets

weapon.effectiveness.shields.dpe = weapon.damage.shields.total / m.getEps() / m.getSustainedFactor();

vs

weapon.effectiveness.shields.dpe = weapon.damage.shields.total / ( m.getEps() / m.getSustainedFactor() );