### PR TITLE
Add SCO Module Check

### DIFF
--- a/src/app/shipyard/ModuleSet.js
+++ b/src/app/shipyard/ModuleSet.js
@@ -41,6 +41,12 @@ export default class ModuleSet {
 
     this.standard[0] = filter(stnd.pp, maxStandardArr[0], 0, mass);  // Power Plant
     this.standard[2] = filter(stnd.fsd, maxStandardArr[2], 0, mass);  // FSD
+    for (let n = this.standard[2].length - 1; n >= 0; n--) {
+      const element = this.standard[2][n];
+      if (element.hasOwnProperty("name") && element.class < maxStandardArr[2]) {
+          this.standard[2].splice(n, 1);  // SCO Modules
+      }
+  }
     this.standard[4] = filter(stnd.pd, maxStandardArr[4], 0, mass);  // Power Distributor
     this.standard[6] = filter(stnd.ft, maxStandardArr[6], 0, mass);  // Fuel Tank
     // Thrusters, filter modules by class only (to show full list of ratings for that class)

--- a/src/app/shipyard/ModuleSet.js
+++ b/src/app/shipyard/ModuleSet.js
@@ -14,6 +14,19 @@ function filter(arr, maxClass, minClass, mass) {
 }
 
 /**
+ * Filter SCO Modules to only return legal size.
+ * @param  {Array}  arr        Array of available FSD modules.
+ * @param  {number} maxSize    Maximum allowable size for SCO modules.
+ * @return {Array}             Subset of modules filtered based on legal size amd type.
+ */
+function sco_filter(arr, maxSize) {
+  return arr.filter(module => {
+    return !(module.hasOwnProperty('name') && module['name'] === "Frame Shift Drive (SCO)" && module['class'] < maxSize);
+  });
+}
+
+
+/**
  * The available module set for a specific ship
  */
 export default class ModuleSet {
@@ -41,12 +54,7 @@ export default class ModuleSet {
 
     this.standard[0] = filter(stnd.pp, maxStandardArr[0], 0, mass);  // Power Plant
     this.standard[2] = filter(stnd.fsd, maxStandardArr[2], 0, mass);  // FSD
-    for (let n = this.standard[2].length - 1; n >= 0; n--) {
-      const element = this.standard[2][n];
-      if (element.hasOwnProperty("name") && element.class < maxStandardArr[2]) {
-          this.standard[2].splice(n, 1);  // SCO Modules
-      }
-  }
+    this.standard[2] = sco_filter(this.standard[2], maxStandardArr[2]) // FSD - Filter SCO Modules
     this.standard[4] = filter(stnd.pd, maxStandardArr[4], 0, mass);  // Power Distributor
     this.standard[6] = filter(stnd.ft, maxStandardArr[6], 0, mass);  // Fuel Tank
     // Thrusters, filter modules by class only (to show full list of ratings for that class)


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/EDCD/coriolis-data/pull/98. 

Adds a check to not display invalid SCO modules (as they cannot be downsized)