### PR TITLE
Added 'special' field to certain modules to allow for clearer …

### DIFF
--- a/src/app/components/AvailableModulesMenu.jsx
+++ b/src/app/components/AvailableModulesMenu.jsx
@@ -48,6 +48,7 @@ const GRPCAT = {
   'pa': 'projectiles',
   'rg': 'projectiles',
   'mr': 'ordnance',
+  'amr': 'ordnance',
   'axmr': 'experimental',
   'axmre': 'experimental',
   'rcpl': 'experimental',
@@ -109,7 +110,7 @@ const CATEGORIES = {
   // Hardpoints
   'lasers': ['pl', 'ul', 'bl'],
   'projectiles': ['mc', 'advmc', 'c', 'fc', 'pa', 'rg'],
-  'ordnance': ['mr', 'tp', 'nl'],
+  'ordnance': ['mr', 'amr', 'tp', 'nl'],
   // Utilities
   'sb': ['sb'],
   'hs': ['hs'],
@@ -259,7 +260,11 @@ export default class AvailableModulesMenu extends TranslatedComponent {
                 } else if (i.mount === 'T') {
                   mount = 'Turreted';
                 }
-                const fuzz = { grp, m: i, name: `${i.class}${i.rating}${mount ? ' '  + mount : ''} ${translate(grp)}` };
+                let special = '';
+                if (typeof(i.special) !== 'undefined') {
+                  special = `(${translate(i.special)})`;
+                }
+                const fuzz = { grp, m: i, name: `${i.class}${i.rating}${mount ? ' '  + mount : ''} ${translate(grp)} ${translate(special)}` };
                 fuzzy.push(fuzz);
               }
             }
@@ -334,7 +339,7 @@ export default class AvailableModulesMenu extends TranslatedComponent {
         disabled = 1 <= ship.internal.filter(o => o.m && o.m.grp === 'mlc').length;
       }
       let active = mountedModule && mountedModule.id === m.id;
-      
+
       let classes = cn(m.name ? 'lc' : 'c', {
         warning: !disabled && warningFunc && warningFunc(m),
         active,

--- a/src/app/i18n/en.json
+++ b/src/app/i18n/en.json
@@ -118,6 +118,7 @@
     "ml": "Mining Laser",
     "mlc": "Multi Limpet Controller",
     "mr": "Missile Rack",
+    "amr": "Missile Rack (Advanced)",
     "axmr": "AX Missile Rack",
     "axmre": "AX Missile Rack (Enhanced)",
     "ews": "Experimental Weapon Stabilizer",


### PR DESCRIPTION
…appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules.

Search for 'missile' without the 'special' field
![image](https://github.com/EDCD/coriolis/assets/958980/efef9207-a9a8-4d2f-acad-982415ab44d1)

Search for 'missile' with the 'special' field
![image](https://github.com/EDCD/coriolis/assets/958980/8fcbf876-f07e-4182-b0f2-6df9827158f4)

Search for 'multi-cannon' without the 'special' field
![image](https://github.com/EDCD/coriolis/assets/958980/606bcd81-7a27-4496-a833-47bb8c848a45)

Search for 'multi-cannon' with the 'special' field
![image](https://github.com/EDCD/coriolis/assets/958980/25ff40c6-c400-4345-8b65-6a78144cfb32)

As can be seen from the screenshots, without the 'special' field, it is impossible to tell the difference between an Enforcer and a normal 1F Fixed MC without selecting one and hoping it's the correct one. The same goes for telling the difference between Seeker and Dumfire Missiles, or even distinguishing Packhounds and/or Groms from... Missiles highlights this the most, as there are five separate '2B Fixed Missile Rack' entries returned by the search... 1 is dumbfire, 1 is a seeker, another is Packhounds, another Groms and finally, the Advanced Missile Rack. This should reduce complaints of hardpoints not existing in Coriolis, when they do, the user simply can't find them with a simple search. It should also make builds much easier.

BREAKING PR: This has an accompanying PR in coriolis-data and will not work properly without both PR's being approved at the same time. If one is approved and the other is not, then the Coriolis code deployed to beta or live, it will break.