### PR TITLE
Description tooltip for experimental effects

### DIFF
--- a/src/app/utils/BlueprintFunctions.js
+++ b/src/app/utils/BlueprintFunctions.js
@@ -12,6 +12,7 @@ import { STATS_FORMATTING } from '../shipyard/StatsFormatting';
  * @returns {Object}              The react components
  */
 export function specialToolTip(translate, blueprint, grp, m, specialName) {
+  const description = [];
   const effects = [];
   if (!blueprint || !blueprint.features) {
     return undefined;
@@ -19,6 +20,16 @@ export function specialToolTip(translate, blueprint, grp, m, specialName) {
   if (m) {
     // We also add in any benefits from specials that aren't covered above
     if (m.blueprint) {
+      if (specialName) {
+        if (Modifications.specials[specialName].description) {
+          description.push(
+            <div className={'success'} style={{ maxWidth: 350, padding: 5, marginBottom: 10 }}>
+              {Modifications.specials[specialName].description}
+            </div>
+          )
+        }
+
+      }
       for (const feature in Modifications.modifierActions[specialName]) {
         // if (!blueprint.features[feature] && !m.mods.feature) {
         const featureDef = Modifications.modifications[feature];
@@ -53,6 +64,7 @@ export function specialToolTip(translate, blueprint, grp, m, specialName) {
 
   return (
     <div>
+      {description}
       <table width='100%'>
         <tbody>
           {effects}


### PR DESCRIPTION
I thought it would be helpful to have a short description on the tooltip for experimental effects when engineering. Some of the names are self-explanatory, but some of them have additional properties that can't easily be explained with stats (corrosive shell, auto-loader, etc.)

The changes to this file look for a property called "description" in the specials.json file. When none is found, nothing is displayed, so we won't be required to change anything right away. 

The corresponding experimental data is stored in the other repository. I figured I would submit this request here to see if you were interested in this change before creating all of the descriptions.

**Sample:**
"special_armour_thermic": {
        "name": "Reflective Plating",
        "id": 143,
        _"description": "Surface coating designed to dissipate thermal energy",_
        "edname": "special_armour_thermic",
        ...
}
**Example:** 
![Coriolis-Tooltip](https://github.com/user-attachments/assets/937a0fe9-32ae-46a3-afee-bf51d0c7ed6f)
**Second Example with Text Wrapping:**
![Coriolis-Tooltip-textwrapping](https://github.com/user-attachments/assets/a04a84cb-2194-4ece-a1f8-f05716a22242)
