### PR TITLE
Remove link to squatted domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-The Coriolis project was inspired by [E:D Shipyard](http://www.edshipyard.com/) and, of course, [Elite Dangerous](http://www.elitedangerous.com). The ultimate goal of Coriolis is to provide rich features to support in-game play and planning while engaging the E:D community to support its development.
+The Coriolis project was inspired by E:D Shipyard and, of course, [Elite Dangerous](http://www.elitedangerous.com). The ultimate goal of Coriolis is to provide rich features to support in-game play and planning while engaging the E:D community to support its development.
 
 Coriolis was created using assets and imagery from Elite: Dangerous, with the permission of Frontier Developments plc, for non-commercial purposes. It is not endorsed by nor reflects the views or opinions of Frontier Developments and no employee of Frontier Developments was involved in the making of it.
 


### PR DESCRIPTION
`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, at least for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.