### PR TITLE
Exclude default modules from searches on inara

### DIFF
--- a/src/app/pages/OutfittingPage.jsx
+++ b/src/app/pages/OutfittingPage.jsx
@@ -690,10 +690,32 @@ export default class OutfittingPage extends Page {
       .map(slot => slot.m.eddbID)
       .filter((v, i, a) => a.indexOf(v) === i);
 
+    // Provide unique default list of non-PP module EDDB IDs
+    let defaultship = new Ship(ship.id, Ships[ship.id].properties, Ships[ship.id].slots); // Create a new Ship instance
+    defaultship.buildWith(Ships[ship.id].defaults); // Populate with default components
+    const defaultModIds = defaultship.internal
+      .concat(defaultship.bulkheads, defaultship.standard, defaultship.hardpoints)
+      .filter(slot => slot !== null && slot.m !== null && !slot.m.pp)
+      .map(slot => slot.m.eddbID)
+      .filter((v, i, a) => a.indexOf(v) === i);
+
+    // Filter list of non-PP module EDDB IDs to exclude default modules
+    for (const modid of defaultModIds) {
+      if (modIds.indexOf(modid) > -1) {
+        modIds.splice(modIds.indexOf(modid), 1);
+      }
+    }
+
     // Open up the relevant URL
-    window.open(
-      'https://inara.cz/inapi/corisearch.php?s=' + shipId + '&m=' + modIds.join(',')
-    );
+    if (modIds.length > 0) {
+      window.open(
+        'https://inara.cz/inapi/corisearch.php?s=' + shipId + '&m=' + modIds.join(',')
+      );
+    } else {
+      window.open(
+        'https://inara.cz/inapi/corisearch.php?s=' + shipId
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
This builds a list of the default modules and then removes them from the current loadout, leading to more accurate searches on inara.

An example where the current system can lead to less accurate results is, when searching a default ship, the hull armor is included, and many more stations may sell the ship than sell the hull armor for the ship, but the hull armor comes default when you buy the ship, even if the station does not sell the hull armor.

The above scenario could happen for any particular E class module as well, where it comes on the ship, but the station itself may not sell it, so therefore would not be a candidate in the current search string.