### PR TITLE
Fixes/mkii passenger cabins (#293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"

--- a/src/app/shipyard/ModuleSet.js
+++ b/src/app/shipyard/ModuleSet.js
@@ -125,10 +125,7 @@ export default class ModuleSet {
       if (key === 'crl' && !eligible) {
         continue;
       }
-      // MKII Passenger Cabins can only be mounted in special 'MkIIPassenger' slots
-      if ((key === 'pcemkii' || key === 'pcimkii') && !eligible) {
-        continue;
-      }
+
       if (key == 'pcq' && !(ship.luxuryCabins && ship.luxuryCabins  === true)) {
         continue;
       }


### PR DESCRIPTION
* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Make modal export better (#26)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------



* Make modal better clean (#29)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

---------



* Add Type 8 to Shipyard, with announcement (#31)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Type 8 added to Shipyard with Announcement

---------



* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Initial Mandalay commit

* Changing date on Announcement of Mandalay

* Add mandalay (#36)

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Initial Mandalay commit

* Changing date on Announcement of Mandalay

* Fixing announcement layout and presentation and expiry control

---------



* Fix boost calc (#38)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Changes to permit boost when capacitor has exact MW needed to boost

---------




* Fix boost calc (#39)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Changes to permit boost when capacitor has exact MW needed to boost

* Fixing module selection warning for power distro

---------




* Add concord cannon (#41)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Adding Concord Cannon

---------




* Display boost intervals better (#42)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Adding boost interval feature

* Adding announcement for boost interval feature

---------




* Minor fixes/update beta announcements (#50)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Develop update with mandalay, type8, concord, new boost int feature (#48)

* Add concord cannon (#45)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Merge Coriolis beta to live - beta.coriolis.io content to deploy on coriolis.io (#14)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

---------





* Live, from Beta (#15)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

---------





* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Beta (#21)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

---------





* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Beta (#22)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

---------





* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Beta to live (#25)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

---------





* Make modal export better (#26)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------



* Make modal export better (#27)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------





* Make modal better clean (#29)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for bet…