### PR TITLE
Feature/add ship mappings json (#297)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env
 .project
 .vscode/
 docs/
+src/ship-mappings.json

--- a/generate-ship-mappings.js
+++ b/generate-ship-mappings.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * generate-ship-mappings.js
+ *
+ * Produces src/ship-mappings.json — a public mapping from Frontier's
+ * internal ship names (as they appear in journal / CAPI data) to
+ * human-readable display names sourced from coriolis-data.
+ *
+ * The file is copied into the build output by webpack's CopyWebpackPlugin
+ * and served at  https://coriolis.io/ship-mappings.json
+ *
+ * Third-party tools (Coriolis CMDR, EDMC plugins, etc.) can fetch this
+ * URL to stay in sync whenever new ships are added to the game.
+ *
+ * Usage:  node generate-ship-mappings.js
+ *         (also called automatically by `npm run build`)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// 1. Parse the FDev → Coriolis key mapping from CompanionApiUtils.js
+//    (It's an ES module export, so we extract it with a regex rather than
+//    requiring it directly.)
+// ---------------------------------------------------------------------------
+const apiUtilsPath = path.join(__dirname, 'src', 'app', 'utils', 'CompanionApiUtils.js');
+const apiUtilsSrc = fs.readFileSync(apiUtilsPath, 'utf8');
+
+const mapMatch = apiUtilsSrc.match(
+  /SHIP_FD_NAME_TO_CORIOLIS_NAME\s*=\s*\{([\s\S]*?)\};/
+);
+if (!mapMatch) {
+  console.error('ERROR: Could not find SHIP_FD_NAME_TO_CORIOLIS_NAME in CompanionApiUtils.js');
+  process.exit(1);
+}
+
+const fdToCoriolisKey = {};
+const lineRe = /['"]([^'"]+)['"]\s*:\s*['"]([^'"]+)['"]/g;
+let m;
+while ((m = lineRe.exec(mapMatch[1])) !== null) {
+  fdToCoriolisKey[m[1]] = m[2];
+}
+
+console.log(`Parsed ${Object.keys(fdToCoriolisKey).length} FDev→Coriolis key mappings`);
+
+// ---------------------------------------------------------------------------
+// 2. Load friendly names from coriolis-data ship JSONs
+// ---------------------------------------------------------------------------
+const shipsDir = path.join(__dirname, 'node_modules', 'coriolis-data', 'ships');
+const coriolisKeyToProps = {};
+
+for (const file of fs.readdirSync(shipsDir).filter(f => f.endsWith('.json'))) {
+  const data = JSON.parse(fs.readFileSync(path.join(shipsDir, file), 'utf8'));
+  for (const [key, val] of Object.entries(data)) {
+    if (val && val.properties && val.properties.name) {
+      coriolisKeyToProps[key] = {
+        name: val.properties.name,
+        manufacturer: val.properties.manufacturer || '',
+        shipClass: val.properties.class || null,
+      };
+    }
+  }
+}
+
+console.log(`Found ${Object.keys(coriolisKeyToProps).length} ships in coriolis-data`);
+
+// ---------------------------------------------------------------------------
+// 3. Build the final mapping:  fdName (lower-cased) → ship info
+// ---------------------------------------------------------------------------
+const mappings = {};
+
+for (const [fdName, coriolisKey] of Object.entries(fdToCoriolisKey)) {
+  const props = coriolisKeyToProps[coriolisKey];
+  if (!props) {
+    console.warn(`  WARNING: no coriolis-data entry for "${coriolisKey}" (FDev: "${fdName}")`);
+    continue;
+  }
+
+  mappings[fdName.toLowerCase()] = {
+    name: props.name,
+    manufacturer: props.manufacturer,
+    shipClass: props.shipClass,
+    coriolisId: coriolisKey,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Write to src/ so CopyWebpackPlugin picks it up during build
+// ---------------------------------------------------------------------------
+const outPath = path.join(__dirname, 'src', 'ship-mappings.json');
+const output = {
+  description:
+    'Mapping from Frontier Developments internal ship names to human-readable names. ' +
+    'Auto-generated from coriolis-data. Do not edit by hand.',
+  generated: new Date().toISOString(),
+  ships: mappings,
+};
+
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+console.log(`Wrote ${Object.keys(mappings).length} ship mappings to ${outPath}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coriolis_shipyard",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/EDCD/coriolis"
@@ -27,14 +27,14 @@
   "scripts": {
     "extract-translations": "grep -hroE \"(translate\\('[^']+'\\))|(tip.bind\\(null, '[^']+')\" src/* | grep -oE \"'[^']+'\" | grep -oE \"[^']+\" | sort -u -f",
     "clean": "rimraf build",
-    "start": "node devServer.js",
+    "start": "node generate-ship-mappings.js && node devServer.js",
     "start:prod": "webpack serve --config webpack.config.prod.js",
     "lint": "eslint --ext .js,.jsx src",
     "test": "jest",
     "prod-serve": "nginx -p $(pwd) -c nginx.conf",
     "prod-stop": "kill -QUIT $(cat nginx.pid)",
     "buildfresh": "rimraf node_modules && rm package-lock.json && npm install && npm run build > >(tee -a stdout.log) 2> >(tee -a stderr.log >&2)",
-    "build": "webpack --config webpack.config.prod.js",
+    "build": "node generate-ship-mappings.js && webpack --config webpack.config.prod.js",
     "rsync": "rsync -ae \"ssh -i $CORIOLIS_PEM\" --delete build/ $CORIOLIS_USER@$CORIOLIS_HOST:~/wwws",
     "deploy": "npm run lint && npm test && npm run build && npm run rsync"
   },

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -16,7 +16,8 @@ module.exports = merge(common, {
       patterns: [
       'src/.htaccess',
       'src/iframe.html',
-      'src/xdLocalStoragePostMessageApi.min.js'
+      'src/xdLocalStoragePostMessageApi.min.js',
+      'src/ship-mappings.json'
     ]}),
     new WebpackNotifierPlugin({ alwaysNotify: true }),
     new webpack.NoEmitOnErrorsPlugin()

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -22,6 +22,7 @@ module.exports = merge(common, {
         'src/.htaccess',
         'src/iframe.html',
         'src/xdLocalStoragePostMessageApi.min.js',
+        'src/ship-mappings.json',
         { from: 'src/schemas', to: 'schemas' },
         {
           from: 'src/images/logo/*',


### PR DESCRIPTION
* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Make modal export better (#26)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------



* Make modal better clean (#29)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

---------



* Add Type 8 to Shipyard, with announcement (#31)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Type 8 added to Shipyard with Announcement

---------



* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Initial Mandalay commit

* Changing date on Announcement of Mandalay

* Add mandalay (#36)

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Initial Mandalay commit

* Changing date on Announcement of Mandalay

* Fixing announcement layout and presentation and expiry control

---------



* Fix boost calc (#38)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Changes to permit boost when capacitor has exact MW needed to boost

---------




* Fix boost calc (#39)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Changes to permit boost when capacitor has exact MW needed to boost

* Fixing module selection warning for power distro

---------




* Add concord cannon (#41)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Adding Concord Cannon

---------




* Display boost intervals better (#42)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Adding boost interval feature

* Adding announcement for boost interval feature

---------




* Minor fixes/update beta announcements (#50)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Modal Changes to export and link shortener

* Remove link to squatted domain

`http://www.edshipyard.com/` is now owned by a Vietnamese betting company (Mu88). Remove the link to avoid giving them traffic.

I considered replacing the link with an archived version, but, for me,  https://web.archive.org/web/20231030223647/http://www.edshipyard.com/ just shows a mostly-white page with some light grey text at the top, so it didn't seem useful.

* Type 8 added to Shipyard with Announcement (#33)

* Develop update with mandalay, type8, concord, new boost int feature (#48)

* Add concord cannon (#45)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Merge Coriolis beta to live - beta.coriolis.io content to deploy on coriolis.io (#14)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

---------





* Live, from Beta (#15)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

---------





* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Beta (#21)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

---------





* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Beta (#22)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

---------





* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Beta to live (#25)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

---------





* Make modal export better (#26)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------



* Make modal export better (#27)

* Update pt.json - Brazilian Portuguese translations (#752)

* Update pt.json

Update Brazilian Portuguese translations:
- Updated Modules
- Engineering & Experimental Effect
- Corrections

* Update Portuguese Brazilian

Fixed Tab/Spaces indentation

* Updated PT-BR translation with Planetary Approach Suite

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fix changed files issue (#3)

* Copied de.js contents to new file de-fix.js

* Copied de.js contents back from de-fix.js

* Copied contents of ko.js to ko-fix.js

* Copied ko.js contents back from ko-fix.js

* Copied contents from BlueprintFunctions.js to BlueprintFunctions-fix.js

* Copied contents back from BlueprintFunctions-fix.js to BlueprintFunctions.js

* Copied contents of LineChart.jsx to LineChart-fix.jsx

* Copied contents back from LineChart-fix.jsx to LineChart.jsx

* Copied contents of PieChart.jsx to PieChart-fix.jsx

* Copied contents back from PieChart-fix.jsx to PieChart.jsx

* Copied contents from Slider.jsx to Slider-fix.jsx

* Copied contents back from Slider-fix.jsx to Slider.jsx

* Copied contents from VerticalBarChart.jsx to VerticalBarChart-fix.jsx

* Copied contents back from VerticalBarChart-fix.jsx to VerticalBarChart.jsx

* Deleting 'fix' files

* Adding workflow for autodeploy

* Improving workflow

* Changed deployment ordering

* Changing to clone single branch for deployment, not the whole repo

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo (#4)

* Issue 754 imports need to be more graceful (#5)

* Adds valid module checking to all types of modules on import

* Changes as per comments on the PR

* Added 'special' field to certain modules to allow for clearer appearance in search results that they are the special type of module. Updated English descriptions of Advanced Modules and Special Modules

* Update PT-BR translations

Added translated strings for coriolis-data PRs 106 & 107

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

* Fixing bug introduced by the previous PR for ISSUE_764. The previous fix introduced a bug which caused Armour Selection to error, due to Armour modules being completely different to other modules of any other type

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Issue 703 edomh integration (#7)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

---------




* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

* Adding in buildname to EDOMH Export

* Issue 703 edomh integration (#8)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

---------




* Issue 703 edomh integration (#9)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

---------




* Issue 703 edomh integration (#10)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Modified export to EDOMH/EDEngineer page to be less 'bodged', allow EDOMH button to be clickable without checking for EDEngineer API (If they have EDOMH, they probably don't have EDEngineer...) and added a workaround for Coriolis sending bogus data for bulkheads.

* Fixed autodeploy to do latest coriolis-data dist. Fixed sendToEDOMH function to only send the blueprint at the selected grade, not each grade up to that grade.

* Fixed miscalculation of mats and got rid of unhelpful 'rolls' table, as the mats are calculated for the whole build and some blueprints may not be all the way up to g5.

* Removed console.log lines which were only needed for testing.

---------




* Issue 764 unknown modules are selectable (#11)

* Adds valid module checking to all types of modules on import

* Adds the Advanced MC's, AX MC's, AX MR's and Nanite Torpedo

* Changes as per comments on the PR

* Fixed 'Missing Module' category showing up in Optional Selection drop-down and fixed 'Missing Power Plant', 'Missing Power Distributor' and 'Missing Frameshift Drive' showing up in the Selection drop-downs for those module slots.

---------




* Adding tag to manual dispatch of workflow

* Adding fix for broken Armour Module Selection

* Fixed issue with special blueprint item not being correctly jsonified for export to EDOMH

* Removing Autodeploy from this branch, it was merged in by github

* Removing debugging console.log entries that are no longer needed for EDOMH fix

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Removing unneccessary output lines from autodeploy (#19)

* Adding missing Constants for Advanced and Enhanced Weaponry (#20)

* Setting up definitive workflows, automatic for when coriolis is being updated, either on its own, or along with coriolis-data and manual, for when we've updated coriolis-data and need to re-deploy.

* Compartmentalising the build stages in the workflows.

* Fixed deployment steps

* deployment fix

* Deployment improvements and potential webpack fix

* Removing webpack change that made no difference.

* Changing deployment workflows to clear out old build before copying new build to web directory

* Supressing npm warnings in build process to avoid failure of the pipeline erroneously.

* Shifting node build to separate runner

* Fixing syntax in autodeploy

* issues with zipping

* Adding GCP Auth to download job

* Fixing unzipping process

* fixes for autodeploy

* zip path issues

* zip path

* rm command

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for beta deployment

* Updating beta autodeploy with nvm info

* Adding autodeploy for live site

* Making autodeploy aware of its target branch name (#16)

* Fixes for autodeploy (#17)

* Autodeploy fixes (#18)

* Fixes for autodeploy

* Adding npm start command to build dist from coriolis-data

* Adding missing Constants for Advanced and Enhanced Weaponry

* Removing workflow code merged in by github

* Fixes for broken EDEngineer button, plus styling changes to improve the modal popup for exporting builds. (#24)

* Improved Modal UI, updated text, restored roll boxes, fixed ED Engineer button hide/show/disable/enable

---------





* Make modal better clean (#29)

* Fix missile rack glitch (#23)

* Adding autodeploy for new 'beta' branch

* Fixing directory for …